### PR TITLE
Iterative deepening, time management, and principal variation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,8 @@
 Chess AI is **brandobot**, a chess engine. A native Rust core (`core/`, the
 `brandobot_core` PyO3 module) owns all chess logic — bitboard move generation,
-evaluation, negamax + alpha-beta, quiescence, MVV-LVA ordering, and a
-transposition table. Two thin Python wrappers are the production entrypoints: a
+evaluation, iterative-deepening negamax with alpha-beta, quiescence, MVV-LVA
+ordering, a transposition table, and time management. Two thin Python wrappers
+are the production entrypoints: a
 UCI engine over stdin/stdout (`src/main.py`, bridged to lichess via lichess-bot)
 and a Flask HTTP API (`src/api.py`).
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -147,7 +147,7 @@ impl Searcher {
             let plies = tree_depth.clamp(1, depth.max(1));
             let nodes = {
                 let mut scout = search::Searcher::new(&mut self.transposition_table, is_endgame);
-                scout.capture_tree(&mut self.board, depth as i32, plies)
+                scout.capture_tree(&mut self.board, depth as i32, plies, 0)
             };
             let captured = nodes.into_iter().map(CapturedNode::from_tree).collect();
             self.last_decision_tree = Some((self.board.to_fen(), captured));
@@ -157,6 +157,66 @@ impl Searcher {
             Some(mv) => mv.to_uci(),
             None => NULL_MOVE.to_string(),
         }
+    }
+
+    /// Iteratively deepen within the given limits and return the result. All
+    /// times are milliseconds. `score_centipawns` is None when a mate is found;
+    /// `mate_in_moves` is the signed moves to mate otherwise.
+    #[pyo3(signature = (max_depth=64, move_time_ms=None, white_time_ms=None,
+                        black_time_ms=None, white_increment_ms=0,
+                        black_increment_ms=0, moves_to_go=None))]
+    #[allow(clippy::too_many_arguments)]
+    fn search<'py>(
+        &mut self,
+        py: Python<'py>,
+        max_depth: u32,
+        move_time_ms: Option<u64>,
+        white_time_ms: Option<u64>,
+        black_time_ms: Option<u64>,
+        white_increment_ms: u64,
+        black_increment_ms: u64,
+        moves_to_go: Option<u32>,
+    ) -> PyResult<Bound<'py, PyDict>> {
+        let is_endgame = eval::is_endgame(&self.board);
+        let limits = search::SearchLimits {
+            max_depth,
+            move_time_ms,
+            white_time_ms,
+            black_time_ms,
+            white_increment_ms,
+            black_increment_ms,
+            moves_to_go,
+        };
+        let result = {
+            let mut searcher = search::Searcher::new(&mut self.transposition_table, is_endgame);
+            searcher.search(&mut self.board, &limits, std::time::Instant::now())
+        };
+
+        let (score_centipawns, mate_in_moves) = match search::mate_in_moves(result.score) {
+            Some(moves) => (None, Some(moves)),
+            None => (Some(result.score), None),
+        };
+        let principal_variation: Vec<String> = result
+            .principal_variation
+            .iter()
+            .map(|mv| mv.to_uci())
+            .collect();
+
+        let dict = PyDict::new(py);
+        dict.set_item(
+            "best_move",
+            result
+                .best_move
+                .map(|mv| mv.to_uci())
+                .unwrap_or_else(|| NULL_MOVE.to_string()),
+        )?;
+        dict.set_item("score_centipawns", score_centipawns)?;
+        dict.set_item("mate_in_moves", mate_in_moves)?;
+        dict.set_item("depth", result.depth)?;
+        dict.set_item("nodes", result.nodes)?;
+        dict.set_item("elapsed_ms", result.elapsed_ms)?;
+        dict.set_item("principal_variation", principal_variation)?;
+        Ok(dict)
     }
 
     /// The decision tree captured by the last `next_move(capture_tree=True)`, or

--- a/core/src/search.rs
+++ b/core/src/search.rs
@@ -1,9 +1,8 @@
-//! Searcher — negamax with alpha-beta pruning, quiescence search, and the
-//! transposition table, a port of `src/searcher.py`.
-//!
-//! `is_endgame` is frozen at the root and threaded through evaluation, matching
-//! the original (which fixes it when the Board is built). Mate scores are flat
-//! ±99999 with no distance-to-mate term, as in the original.
+//! Searcher — iterative deepening with alpha-beta pruning, quiescence, the
+//! transposition table, mate-distance scoring, and a triangular principal
+//! variation. Deepens one ply at a time within a time budget.
+
+use std::time::{Duration, Instant};
 
 use crate::board::Board;
 use crate::chess_move::Move;
@@ -13,12 +12,47 @@ use crate::movesort::{get_moves_to_dequiet, in_check, prioritize_legal_moves};
 use crate::tt::{Flag, HashEntry, TranspositionTable};
 use crate::types::Color;
 
+/// A checkmate scores `MATE - ply`; any score within `MAX_PLY` of `MATE` is a mate.
 const MATE: i32 = 99999;
+const MAX_PLY: i32 = 1000;
+const MATE_THRESHOLD: i32 = MATE - MAX_PLY;
 /// Quiescence stops descending captures below this depth.
 const QUIESCENCE_FLOOR: i32 = -5;
+/// Poll the clock every this many nodes.
+const STOP_CHECK_INTERVAL: u64 = 2048;
+/// Reserve this much wall-clock so the engine never flags.
+const MOVE_OVERHEAD_MS: u64 = 50;
+/// Sudden-death moves-to-go assumption.
+const SUDDEN_DEATH_MOVES: u64 = 30;
+/// Cap a move at this fraction of the remaining time (percent).
+const MAX_BUDGET_PERCENT: u64 = 40;
+/// PV table / ply array bound.
+const MAX_SEARCH_PLY: usize = 128;
 
-/// A node in a captured decision tree: a move, its negamax value, and the reply
-/// tree beneath it (empty at the configured leaf depth).
+/// The limits for one search. All times are milliseconds.
+#[derive(Clone, Copy, Default)]
+pub struct SearchLimits {
+    pub max_depth: u32,
+    pub move_time_ms: Option<u64>,
+    pub white_time_ms: Option<u64>,
+    pub black_time_ms: Option<u64>,
+    pub white_increment_ms: u64,
+    pub black_increment_ms: u64,
+    pub moves_to_go: Option<u32>,
+}
+
+/// The outcome of a search. `score` is internal (centipawns or a mate score);
+/// the seam converts it to `score_centipawns` / `mate_in_moves`.
+pub struct SearchResult {
+    pub best_move: Option<Move>,
+    pub score: i32,
+    pub depth: i32,
+    pub nodes: u64,
+    pub elapsed_ms: u64,
+    pub principal_variation: Vec<Move>,
+}
+
+/// A node in a captured decision tree (debug diagnostic).
 pub struct TreeNode {
     pub mv: Move,
     pub value: i32,
@@ -30,6 +64,11 @@ pub struct Searcher<'a> {
     is_endgame: bool,
     /// Zobrist keys along the current line, for threefold-repetition detection.
     history: Vec<u64>,
+    nodes: u64,
+    deadline: Option<Instant>,
+    stopped: bool,
+    /// Triangular table: `pv_table[ply]` is the principal variation from `ply`.
+    pv_table: Vec<Vec<Move>>,
 }
 
 impl<'a> Searcher<'a> {
@@ -38,13 +77,62 @@ impl<'a> Searcher<'a> {
             transposition_table,
             is_endgame,
             history: Vec::new(),
+            nodes: 0,
+            deadline: None,
+            stopped: false,
+            pv_table: vec![Vec::new(); MAX_SEARCH_PLY],
         }
     }
 
-    /// The best move for the side to move. When checkmate is unavoidable and the
-    /// search names no move, fall back to the first ordered move — we must move.
+    /// Iteratively deepen within `limits` and return the best result. `now` is the
+    /// search start; the clock is measured from it.
+    pub fn search(
+        &mut self,
+        board: &mut Board,
+        limits: &SearchLimits,
+        now: Instant,
+    ) -> SearchResult {
+        self.deadline = compute_budget_ms(board.side_to_move(), limits)
+            .map(|budget| now + Duration::from_millis(budget));
+        let max_depth = limits.max_depth.max(1) as i32;
+
+        // Fallback so we always return a legal move, even if depth 1 is cut off.
+        let mut result = SearchResult {
+            best_move: prioritize_legal_moves(board, self.is_endgame)
+                .into_iter()
+                .next(),
+            score: 0,
+            depth: 0,
+            nodes: 0,
+            elapsed_ms: 0,
+            principal_variation: Vec::new(),
+        };
+
+        for depth in 1..=max_depth {
+            let (best_move, score) = self.negamax(board, depth, -MATE, MATE, 0);
+            if self.stopped {
+                break; // discard this incomplete iteration
+            }
+            if best_move.is_some() {
+                result.best_move = best_move;
+            }
+            result.score = score;
+            result.depth = depth;
+            result.principal_variation = self.pv_table[0].clone();
+            if is_mate_score(score) {
+                break; // a forced mate is found; deeper search cannot improve it
+            }
+        }
+
+        result.nodes = self.nodes;
+        result.elapsed_ms = now.elapsed().as_millis() as u64;
+        result
+    }
+
+    /// The best move searched to a fixed `depth`, no time limit. Used by the HTTP
+    /// path and the tactical tests.
     pub fn best_move(&mut self, board: &mut Board, depth: i32) -> Option<Move> {
-        let (best, _value) = self.negamax(board, depth, -MATE, MATE);
+        let (best, _score) = self.negamax(board, depth, -MATE, MATE, 0);
         best.or_else(|| {
             prioritize_legal_moves(board, self.is_endgame)
                 .into_iter()
@@ -52,16 +140,13 @@ impl<'a> Searcher<'a> {
         })
     }
 
-    /// Capture a decision tree `tree_depth` plies deep — the data behind the
-    /// decision-tree debug endpoint. Each node pairs a move with its negamax
-    /// value at the remaining search depth (full window, so the score is exact);
-    /// children expand the reply tree one ply further. Debug-only and re-searches
-    /// every node, so keep `tree_depth` small.
+    /// Capture a decision tree `tree_depth` plies deep — the debug diagnostic.
     pub fn capture_tree(
         &mut self,
         board: &mut Board,
         search_depth: i32,
         tree_depth: u32,
+        ply: i32,
     ) -> Vec<TreeNode> {
         if tree_depth == 0 {
             return Vec::new();
@@ -70,16 +155,30 @@ impl<'a> Searcher<'a> {
         let mut nodes = Vec::with_capacity(moves.len());
         for mv in moves {
             let undo = board.make_move(mv);
-            let (_, child_value) = self.negamax(board, search_depth - 1, -MATE, MATE);
-            let children = self.capture_tree(board, search_depth - 1, tree_depth - 1);
+            let (_, child_score) = self.negamax(board, search_depth - 1, -MATE, MATE, ply + 1);
+            let children = self.capture_tree(board, search_depth - 1, tree_depth - 1, ply + 1);
             board.unmake_move(mv, undo);
             nodes.push(TreeNode {
                 mv,
-                value: -child_value,
+                value: -child_score,
                 children,
             });
         }
         nodes
+    }
+
+    fn should_stop(&mut self) -> bool {
+        if self.stopped {
+            return true;
+        }
+        if self.nodes.is_multiple_of(STOP_CHECK_INTERVAL) {
+            if let Some(deadline) = self.deadline {
+                if Instant::now() >= deadline {
+                    self.stopped = true;
+                }
+            }
+        }
+        self.stopped
     }
 
     fn negamax(
@@ -88,10 +187,11 @@ impl<'a> Searcher<'a> {
         depth: i32,
         alpha: i32,
         beta: i32,
+        ply: i32,
     ) -> (Option<Move>, i32) {
-        let key = board.zobrist();
-        self.history.push(key);
-        let result = self.search_node(board, depth, alpha, beta, key);
+        let zobrist_key = board.zobrist();
+        self.history.push(zobrist_key);
+        let result = self.search_node(board, depth, alpha, beta, ply, zobrist_key);
         self.history.pop();
         result
     }
@@ -102,41 +202,53 @@ impl<'a> Searcher<'a> {
         depth: i32,
         mut alpha: i32,
         mut beta: i32,
-        key: u64,
+        ply: i32,
+        zobrist_key: u64,
     ) -> (Option<Move>, i32) {
-        let checked = in_check(board);
+        self.nodes += 1;
+        if self.should_stop() {
+            return (None, 0);
+        }
+        if (ply as usize) < MAX_SEARCH_PLY {
+            self.pv_table[ply as usize].clear();
+        }
+
+        let is_in_check = in_check(board);
         let has_legal_move = !generate_legal(board).is_empty();
 
-        if !has_legal_move && checked {
-            return (None, -MATE);
+        if !has_legal_move && is_in_check {
+            return (None, -(MATE - ply));
         }
-        if depth > 0 && ((!has_legal_move && !checked) || self.is_draw(board, key)) {
+        if depth > 0 && ((!has_legal_move && !is_in_check) || self.is_draw(board, zobrist_key)) {
             return (None, 0);
         }
 
-        let alpha_orig = alpha;
+        let original_alpha = alpha;
 
-        if let Some(stored) = self.transposition_table.get(key, depth) {
-            if stored.depth <= depth {
+        let stored_entry = self.transposition_table.probe(zobrist_key);
+        if let Some(stored) = stored_entry {
+            if stored.depth >= depth {
+                let value = value_from_tt(stored.value, ply);
                 match stored.flag {
-                    Flag::Exact => return (stored.best_move, stored.value),
-                    Flag::LowerBound => alpha = alpha.max(stored.value),
-                    Flag::UpperBound => beta = beta.min(stored.value),
+                    Flag::Exact => return (stored.best_move, value),
+                    Flag::LowerBound => alpha = alpha.max(value),
+                    Flag::UpperBound => beta = beta.min(value),
                 }
                 if alpha >= beta {
-                    return (stored.best_move, stored.value);
+                    return (stored.best_move, value);
                 }
             }
         }
+        let tt_move = stored_entry.and_then(|entry| entry.best_move);
 
         let moves = if depth <= 0 {
-            let sign = if board.side_to_move() == Color::White {
+            let perspective = if board.side_to_move() == Color::White {
                 1
             } else {
                 -1
             };
-            let stand_pat = eval::value(board, self.is_endgame) * sign;
-            if !checked {
+            let stand_pat = eval::value(board, self.is_endgame) * perspective;
+            if !is_in_check {
                 if stand_pat >= beta {
                     return (None, beta);
                 }
@@ -149,66 +261,163 @@ impl<'a> Searcher<'a> {
             if captures_and_checks.is_empty() {
                 return (None, stand_pat);
             }
-            captures_and_checks
+            order_tt_move_first(captures_and_checks, tt_move)
         } else {
-            prioritize_legal_moves(board, self.is_endgame)
+            order_tt_move_first(prioritize_legal_moves(board, self.is_endgame), tt_move)
         };
 
-        let mut max_val = -MATE;
+        let mut best_score = -MATE;
         let mut best_move: Option<Move> = None;
         for mv in moves {
             let undo = board.make_move(mv);
-            let (_, child) = self.negamax(board, depth - 1, -beta, -alpha);
+            let (_, child_score) = self.negamax(board, depth - 1, -beta, -alpha, ply + 1);
             board.unmake_move(mv, undo);
-            let move_eval = -child;
+            if self.stopped {
+                return (None, 0);
+            }
+            let move_score = -child_score;
 
-            if depth <= 0 && move_eval >= beta {
+            if depth <= 0 && move_score >= beta {
                 return (best_move, beta);
             }
-            if move_eval > max_val {
+            if move_score > best_score {
+                best_score = move_score;
                 best_move = Some(mv);
+                if depth > 0 {
+                    self.update_pv(ply, mv);
+                }
             }
-            max_val = max_val.max(move_eval);
-            alpha = alpha.max(max_val);
+            alpha = alpha.max(best_score);
             if alpha >= beta {
                 break;
             }
         }
 
-        let flag = if max_val <= alpha_orig {
+        let flag = if best_score <= original_alpha {
             Flag::UpperBound
-        } else if max_val >= beta {
+        } else if best_score >= beta {
             Flag::LowerBound
         } else {
             Flag::Exact
         };
         self.transposition_table.replace(HashEntry {
-            zobrist: key,
+            zobrist: zobrist_key,
             best_move,
             depth,
-            value: max_val,
+            value: value_to_tt(best_score, ply),
             flag,
             age: board.halfmove_clock(),
         });
 
-        (best_move, max_val)
+        (best_move, best_score)
     }
 
-    fn is_draw(&self, board: &Board, key: u64) -> bool {
+    fn update_pv(&mut self, ply: i32, mv: Move) {
+        let ply = ply as usize;
+        if ply + 1 >= MAX_SEARCH_PLY {
+            return;
+        }
+        let mut line = Vec::with_capacity(self.pv_table[ply + 1].len() + 1);
+        line.push(mv);
+        let child_line = self.pv_table[ply + 1].clone();
+        line.extend(child_line);
+        self.pv_table[ply] = line;
+    }
+
+    fn is_draw(&self, board: &Board, zobrist_key: u64) -> bool {
         if board.halfmove_clock() >= 100 {
             return true;
         }
-        self.history.iter().filter(|&&seen| seen == key).count() >= 3
+        self.history
+            .iter()
+            .filter(|&&seen| seen == zobrist_key)
+            .count()
+            >= 3
     }
+}
+
+pub fn is_mate_score(score: i32) -> bool {
+    score.abs() >= MATE_THRESHOLD
+}
+
+/// The number of moves to mate, signed (positive when the side to move gives
+/// mate), or None when `score` is not a mate score. UCI `score mate` is in moves.
+pub fn mate_in_moves(score: i32) -> Option<i32> {
+    if score >= MATE_THRESHOLD {
+        Some((MATE - score + 1) / 2)
+    } else if score <= -MATE_THRESHOLD {
+        Some(-((MATE + score + 1) / 2))
+    } else {
+        None
+    }
+}
+
+/// Store mate scores relative to the node (add the distance to root), so a
+/// transposed entry stays correct.
+fn value_to_tt(value: i32, ply: i32) -> i32 {
+    if value >= MATE_THRESHOLD {
+        value + ply
+    } else if value <= -MATE_THRESHOLD {
+        value - ply
+    } else {
+        value
+    }
+}
+
+/// Re-relativize a stored mate score to this node's distance from the root.
+fn value_from_tt(value: i32, ply: i32) -> i32 {
+    if value >= MATE_THRESHOLD {
+        value - ply
+    } else if value <= -MATE_THRESHOLD {
+        value + ply
+    } else {
+        value
+    }
+}
+
+/// Promote the transposition-table move to the front, preserving the order of the
+/// rest.
+fn order_tt_move_first(mut moves: Vec<Move>, tt_move: Option<Move>) -> Vec<Move> {
+    if let Some(tt_move) = tt_move {
+        if let Some(index) = moves.iter().position(|&candidate| candidate == tt_move) {
+            moves[..=index].rotate_right(1);
+        }
+    }
+    moves
+}
+
+/// The per-move time budget in milliseconds, or None for a depth-only search.
+fn compute_budget_ms(side: Color, limits: &SearchLimits) -> Option<u64> {
+    if let Some(move_time) = limits.move_time_ms {
+        return Some(move_time.saturating_sub(MOVE_OVERHEAD_MS));
+    }
+    let (remaining, increment) = match side {
+        Color::White => (limits.white_time_ms, limits.white_increment_ms),
+        Color::Black => (limits.black_time_ms, limits.black_increment_ms),
+    };
+    let remaining = remaining?;
+    let divisor = limits
+        .moves_to_go
+        .map(|moves| moves as u64)
+        .unwrap_or(SUDDEN_DEATH_MOVES)
+        .max(1);
+    let budget = remaining / divisor + increment * 7 / 10;
+    let cap = remaining * MAX_BUDGET_PERCENT / 100;
+    Some(budget.min(cap).saturating_sub(MOVE_OVERHEAD_MS))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    fn searcher_for(fen: &str) -> (Board, TranspositionTable) {
+        let board = Board::from_fen(fen).unwrap();
+        let table = TranspositionTable::new();
+        (board, table)
+    }
+
     fn best(fen: &str, depth: i32) -> String {
-        let mut board = Board::from_fen(fen).unwrap();
-        let mut table = TranspositionTable::new();
+        let (mut board, mut table) = searcher_for(fen);
         let is_endgame = eval::is_endgame(&board);
         let mut searcher = Searcher::new(&mut table, is_endgame);
         searcher
@@ -216,6 +425,19 @@ mod tests {
             .expect("a legal move exists")
             .to_uci()
     }
+
+    fn run_search(fen: &str, limits: SearchLimits) -> SearchResult {
+        let (mut board, mut table) = searcher_for(fen);
+        let is_endgame = eval::is_endgame(&board);
+        let mut searcher = Searcher::new(&mut table, is_endgame);
+        searcher.search(&mut board, &limits, Instant::now())
+    }
+
+    const STARTPOS: &str = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+    const MIDGAME: &str = "r1bqk2r/pppp1ppp/2n2n2/2b1p3/2B1P3/3P1N2/PPP2PPP/RNBQK2R w KQkq - 0 1";
+    const MATE_IN_ONE: &str = "6k1/5ppp/8/8/8/8/5PPP/R5K1 w - - 0 1";
+
+    // --- Wave 6: tactics preserved ---
 
     #[test]
     fn blocks_the_threatened_mate() {
@@ -250,5 +472,185 @@ mod tests {
             best("2r3k1/6p1/5p1p/p2r4/3p4/6B1/PPP2PPP/R3R1K1 w - - 0 1", 3),
             "e1e8"
         );
+    }
+
+    // --- Wave 2: time budget ---
+
+    #[test]
+    fn budget_honors_movetime() {
+        let limits = SearchLimits {
+            move_time_ms: Some(1000),
+            ..Default::default()
+        };
+        assert_eq!(compute_budget_ms(Color::White, &limits), Some(950));
+    }
+
+    #[test]
+    fn budget_in_sudden_death_is_a_thirtieth_plus_increment() {
+        let limits = SearchLimits {
+            white_time_ms: Some(60_000),
+            white_increment_ms: 1_000,
+            ..Default::default()
+        };
+        // 60000/30 + 0.7*1000 - 50 = 2000 + 700 - 50.
+        assert_eq!(compute_budget_ms(Color::White, &limits), Some(2_650));
+    }
+
+    #[test]
+    fn budget_divides_by_moves_to_go() {
+        let limits = SearchLimits {
+            white_time_ms: Some(60_000),
+            moves_to_go: Some(10),
+            ..Default::default()
+        };
+        assert_eq!(compute_budget_ms(Color::White, &limits), Some(5_950));
+    }
+
+    #[test]
+    fn budget_is_capped_at_forty_percent() {
+        let limits = SearchLimits {
+            white_time_ms: Some(1_000),
+            moves_to_go: Some(1),
+            ..Default::default()
+        };
+        // remaining/1 = 1000, capped to 400, minus 50.
+        assert_eq!(compute_budget_ms(Color::White, &limits), Some(350));
+    }
+
+    #[test]
+    fn budget_is_none_without_a_clock_or_movetime() {
+        let limits = SearchLimits {
+            max_depth: 4,
+            ..Default::default()
+        };
+        assert_eq!(compute_budget_ms(Color::White, &limits), None);
+    }
+
+    // --- Wave 3: iterative deepening loop ---
+
+    #[test]
+    fn search_reaches_the_requested_depth() {
+        let result = run_search(
+            STARTPOS,
+            SearchLimits {
+                max_depth: 4,
+                ..Default::default()
+            },
+        );
+        assert_eq!(result.depth, 4);
+        assert!(result.best_move.is_some());
+    }
+
+    #[test]
+    fn a_tiny_budget_still_returns_a_move() {
+        let result = run_search(
+            MIDGAME,
+            SearchLimits {
+                max_depth: 64,
+                move_time_ms: Some(1),
+                ..Default::default()
+            },
+        );
+        assert!(result.best_move.is_some());
+    }
+
+    #[test]
+    fn a_movetime_search_stays_within_a_sane_bound() {
+        let result = run_search(
+            MIDGAME,
+            SearchLimits {
+                max_depth: 64,
+                move_time_ms: Some(200),
+                ..Default::default()
+            },
+        );
+        assert!(result.best_move.is_some());
+        assert!(result.elapsed_ms < 2_000, "elapsed {}", result.elapsed_ms);
+    }
+
+    // --- Wave 4: principal variation ---
+
+    #[test]
+    fn pv_first_move_is_the_best_move() {
+        let result = run_search(
+            STARTPOS,
+            SearchLimits {
+                max_depth: 4,
+                ..Default::default()
+            },
+        );
+        assert_eq!(
+            result.principal_variation.first().copied(),
+            result.best_move
+        );
+    }
+
+    #[test]
+    fn pv_is_a_legal_sequence() {
+        let result = run_search(
+            MIDGAME,
+            SearchLimits {
+                max_depth: 4,
+                ..Default::default()
+            },
+        );
+        let mut board = Board::from_fen(MIDGAME).unwrap();
+        for mv in &result.principal_variation {
+            let legal = generate_legal(&mut board);
+            assert!(legal.contains(mv), "{} not legal", mv.to_uci());
+            board.make_move(*mv);
+        }
+    }
+
+    // --- Wave 1.2: mate-distance scoring ---
+
+    #[test]
+    fn mate_score_survives_a_tt_round_trip() {
+        let root_relative = MATE - 5;
+        let stored = value_to_tt(root_relative, 3);
+        assert_eq!(value_from_tt(stored, 3), root_relative);
+    }
+
+    #[test]
+    fn a_faster_mate_scores_higher() {
+        let mate_in_one = run_search(
+            MATE_IN_ONE,
+            SearchLimits {
+                max_depth: 4,
+                ..Default::default()
+            },
+        );
+        let mate_in_three = run_search(
+            "r5rk/5p1p/5R2/4B3/8/8/7P/7K w",
+            SearchLimits {
+                max_depth: 4,
+                ..Default::default()
+            },
+        );
+        assert!(is_mate_score(mate_in_one.score));
+        assert!(is_mate_score(mate_in_three.score));
+        assert!(mate_in_one.score > mate_in_three.score);
+        assert_eq!(mate_in_moves(mate_in_one.score), Some(1));
+        assert_eq!(mate_in_moves(mate_in_three.score), Some(3));
+    }
+
+    // --- Wave 1.1: transposition-table reuse ---
+
+    #[test]
+    fn a_warm_table_reduces_nodes() {
+        fn nodes(fen: &str, depth: i32, warm: bool) -> u64 {
+            let (mut board, mut table) = searcher_for(fen);
+            let is_endgame = eval::is_endgame(&board);
+            if warm {
+                let mut warmup = Searcher::new(&mut table, is_endgame);
+                warmup.best_move(&mut board, depth - 1);
+            }
+            let mut searcher = Searcher::new(&mut table, is_endgame);
+            searcher.best_move(&mut board, depth);
+            searcher.nodes
+        }
+        let cold = nodes(MIDGAME, 5, false);
+        let warm = nodes(MIDGAME, 5, true);
+        assert!(warm < cold, "warm {warm} should be < cold {cold}");
     }
 }

--- a/core/src/tt.rs
+++ b/core/src/tt.rs
@@ -54,11 +54,13 @@ impl TranspositionTable {
         }
     }
 
-    /// The stored entry, if its key matches and it was searched at least as deep.
-    pub fn get(&self, zobrist: u64, depth: i32) -> Option<HashEntry> {
+    /// The stored entry whose key matches, regardless of depth. The search
+    /// decides whether the entry is deep enough to cut; even a shallow entry
+    /// seeds move ordering with its best Move.
+    pub fn probe(&self, zobrist: u64) -> Option<HashEntry> {
         let index = (zobrist % TABLE_SIZE as u64) as usize;
         match self.table[index] {
-            Some(stored) if stored.zobrist == zobrist && stored.depth >= depth => Some(stored),
+            Some(stored) if stored.zobrist == zobrist => Some(stored),
             _ => None,
         }
     }
@@ -88,7 +90,7 @@ mod tests {
         let mut table = TranspositionTable::new();
         let stored = entry(5, 0);
         table.replace(stored);
-        assert_eq!(table.get(0xABCD, 5), Some(stored));
+        assert_eq!(table.probe(0xABCD), Some(stored));
     }
 
     #[test]
@@ -97,7 +99,7 @@ mod tests {
         table.replace(entry(5, 0));
         let newer = entry(5, 2);
         table.replace(newer);
-        assert_eq!(table.get(0xABCD, 5), Some(newer));
+        assert_eq!(table.probe(0xABCD), Some(newer));
     }
 
     #[test]
@@ -106,7 +108,7 @@ mod tests {
         table.replace(entry(4, 0));
         let deeper = entry(5, 0);
         table.replace(deeper);
-        assert_eq!(table.get(0xABCD, 5), Some(deeper));
+        assert_eq!(table.probe(0xABCD), Some(deeper));
     }
 
     #[test]
@@ -115,6 +117,6 @@ mod tests {
         let deeper = entry(5, 0);
         table.replace(deeper);
         table.replace(entry(4, 0));
-        assert_eq!(table.get(0xABCD, 5), Some(deeper));
+        assert_eq!(table.probe(0xABCD), Some(deeper));
     }
 }

--- a/features/engine.feature
+++ b/features/engine.feature
@@ -6,3 +6,9 @@ Feature: UCI chess engine
     Given the chess engine is available
     When it receives the "uci" command
     Then it replies "uciok"
+
+  Scenario: it reports a move and a principal variation under a movetime budget
+    Given the chess engine is available
+    When it searches the start position with "movetime 200"
+    Then it replies "bestmove"
+    And it reports a principal variation

--- a/knowledge/glossary.md
+++ b/knowledge/glossary.md
@@ -53,11 +53,19 @@ field, and record must fit. The chess logic lives in the Rust core
 | Magic bitboard | Perfect-hash lookup of a slider's attacks by blocker configuration | | |
 | Make/unmake | Apply a Move, then reverse it, updating the Zobrist key incrementally | `make_move` / `unmake_move` | |
 | Piece-square table | Per-piece, per-square positional bonus added to material in evaluation | | |
-| Principal variation | The best line of play the search currently expects (planned) | `pline` | |
+| Principal variation | The best line the search expects; reported each iteration | `principal_variation` (UCI `pv`) | `pline` |
+| Iterative deepening | Search depth 1, 2, 3 … reusing each iteration's results for ordering | `SearchLimits.max_depth` | |
+| Triangular PV-table | Ply-indexed array that collects the principal variation | `pv_table` | |
+| Mate score | A score near ±`MATE`, offset by distance to the root; reported as `mate_in_moves` | `is_mate_score` | |
+| Centipawn | Evaluation unit, one hundredth of a pawn | `score_centipawns` (UCI `cp`) | |
+| Time control | The UCI clock tokens the wrapper parses into a per-move budget | `wtime`/`btime`/`winc`/`binc`/`movetime`/`movestogo` | |
+| SearchLimits | The parsed per-search limits, depth and time | `SearchLimits` | |
 | Perft | Performance test — counts leaf nodes to a depth to validate move generation | `perft(fen, depth)` | |
 | Endgame | Late-game phase that triggers deeper search | `Board::is_endgame` | |
 | brandobot_core | The Rust engine core exposed to Python as a PyO3 module | `import brandobot_core` | |
 
-Bitboard, magic bitboard, make/unmake, piece-square table, and negamax follow
-[Chess Programming Wiki](https://www.chessprogramming.org/) conventions; perft
-and MVV-LVA already did. `brandobot_core` is this repo's PyO3 module name.
+Bitboard, magic bitboard, make/unmake, piece-square table, negamax, iterative
+deepening, the triangular PV-table, mate scores, and the centipawn follow
+[Chess Programming Wiki](https://www.chessprogramming.org/) conventions; perft and
+MVV-LVA already did. The time-control tokens are UCI; `SearchLimits` follows
+Stockfish's `LimitsType`. `brandobot_core` is this repo's PyO3 module name.

--- a/roadmap/ROADMAP.md
+++ b/roadmap/ROADMAP.md
@@ -64,12 +64,15 @@ Searcher.
 
 ### Epic 1 — Iterative deepening with principal variation
 
-Replace fixed-depth search with iterative deepening that reuses the
-transposition table and reports the principal variation — improving move
-quality and enabling time management. Built on the Rust Searcher.
+Replace fixed-depth search with iterative deepening on the Rust Searcher: deepen
+within a time budget, reuse the transposition table across depths, and report the
+principal variation. Improves move quality and enables timed play on lichess.
 
 | Work | Status | Spec | Depends on |
 |---|---|---|---|
-| Iterative-deepening search loop in `Searcher` | Backlog | — | Rust engine core |
-| Principal variation reporting (`info pv` over UCI) | Backlog | — | Iterative-deepening search loop |
-| Time-managed `go` (stop at a time budget) | Backlog | — | Iterative-deepening search loop |
+| Transposition-table reuse + mate-distance scoring | Planned | [iterative-deepening](specs/iterative-deepening/design.md) | Rust engine core |
+| Time budget (`SearchLimits`) | Planned | [iterative-deepening](specs/iterative-deepening/design.md) | Transposition-table reuse + mate-distance scoring |
+| Iterative-deepening loop + stop | Planned | [iterative-deepening](specs/iterative-deepening/design.md) | Time budget (`SearchLimits`) |
+| Principal variation (triangular PV-table) | Planned | [iterative-deepening](specs/iterative-deepening/design.md) | Iterative-deepening loop + stop |
+| Time-aware `search` seam (PyO3) | Planned | [iterative-deepening](specs/iterative-deepening/design.md) | Principal variation (triangular PV-table) |
+| UCI time controls (`go` + `info pv`) | Planned | [iterative-deepening](specs/iterative-deepening/design.md) | Time-aware `search` seam (PyO3) |

--- a/roadmap/ROADMAP.md
+++ b/roadmap/ROADMAP.md
@@ -70,9 +70,9 @@ principal variation. Improves move quality and enables timed play on lichess.
 
 | Work | Status | Spec | Depends on |
 |---|---|---|---|
-| Transposition-table reuse + mate-distance scoring | Planned | [iterative-deepening](specs/iterative-deepening/design.md) | Rust engine core |
-| Time budget (`SearchLimits`) | Planned | [iterative-deepening](specs/iterative-deepening/design.md) | Transposition-table reuse + mate-distance scoring |
-| Iterative-deepening loop + stop | Planned | [iterative-deepening](specs/iterative-deepening/design.md) | Time budget (`SearchLimits`) |
-| Principal variation (triangular PV-table) | Planned | [iterative-deepening](specs/iterative-deepening/design.md) | Iterative-deepening loop + stop |
-| Time-aware `search` seam (PyO3) | Planned | [iterative-deepening](specs/iterative-deepening/design.md) | Principal variation (triangular PV-table) |
-| UCI time controls (`go` + `info pv`) | Planned | [iterative-deepening](specs/iterative-deepening/design.md) | Time-aware `search` seam (PyO3) |
+| Transposition-table reuse + mate-distance scoring (@branransom) | Done | [iterative-deepening](specs/iterative-deepening/design.md) | Rust engine core |
+| Time budget (`SearchLimits`) (@branransom) | Done | [iterative-deepening](specs/iterative-deepening/design.md) | Transposition-table reuse + mate-distance scoring |
+| Iterative-deepening loop + stop (@branransom) | Done | [iterative-deepening](specs/iterative-deepening/design.md) | Time budget (`SearchLimits`) |
+| Principal variation (triangular PV-table) (@branransom) | Done | [iterative-deepening](specs/iterative-deepening/design.md) | Iterative-deepening loop + stop |
+| Time-aware `search` seam (PyO3) (@branransom) | Done | [iterative-deepening](specs/iterative-deepening/design.md) | Principal variation (triangular PV-table) |
+| UCI time controls (`go` + `info pv`) (@branransom) | Done | [iterative-deepening](specs/iterative-deepening/design.md) | Time-aware `search` seam (PyO3) |

--- a/roadmap/specs/iterative-deepening/design.md
+++ b/roadmap/specs/iterative-deepening/design.md
@@ -3,7 +3,7 @@ title: Iterative deepening — design
 description: Architecture and decisions for iterative deepening, time management, and principal variation, with UCI/CPW-faithful naming.
 ---
 
-> **Status:** Planned (2026-06-15) — tracked on the [board](../../ROADMAP.md).
+> **Status:** Done (2026-06-15) — tracked on the [board](../../ROADMAP.md).
 
 # Iterative deepening — design
 

--- a/roadmap/specs/iterative-deepening/design.md
+++ b/roadmap/specs/iterative-deepening/design.md
@@ -1,0 +1,167 @@
+---
+title: Iterative deepening — design
+description: Architecture and decisions for iterative deepening, time management, and principal variation, with UCI/CPW-faithful naming.
+---
+
+> **Status:** Planned (2026-06-15) — tracked on the [board](../../ROADMAP.md).
+
+# Iterative deepening — design
+
+## Decision summary
+
+| Decision | Choice | Why |
+|---|---|---|
+| Time policy | Clock fraction | Predictable and safe: `remaining/movestogo (or /30) + 0.7·inc`, capped at 40%. |
+| Scope | Core + TT fix | Iterative deepening, time-managed `go`, PV, the TT reuse fix, and mate-distance scoring. Killers/history/aspiration deferred. |
+| Stop | Deadline + node poll | Check the clock every ~2048 nodes; discard a half-finished iteration. |
+| PV | Triangular PV-table | Robust against TT overwrites. |
+| Mate scores | Distance to root | A faster mate wins; `info` reports `score mate` correctly. |
+| Naming | UCI tokens at the boundary; expressive names inside | The wrapper speaks UCI; the core reads with full names and translates between them. |
+
+## The seam
+
+The core gains one time-aware entry point. `Searcher.search` deepens against a
+deadline and returns a result dict with expressive keys. `next_move` stays as-is
+for the HTTP decision-tree path.
+
+```python
+searcher.search(max_depth=64, move_time_ms=None,
+                white_time_ms=None, black_time_ms=None,
+                white_increment_ms=0, black_increment_ms=0,
+                moves_to_go=None) -> {
+    "best_move": "e2e4",
+    "score_centipawns": 31,       # side-to-move POV; None when a mate is found
+    "mate_in_moves": None,        # signed moves to mate; None when not a mate
+    "depth": 9,                   # last completed depth, plies
+    "nodes": 240117,
+    "elapsed_ms": 842,
+    "principal_variation": ["e2e4", "e7e5", "g1f3"] }
+```
+
+All times are milliseconds. `SearchLimits` (Rust) holds the inputs under the same
+field names. UCI token spellings appear only in the wrapper (see Naming).
+
+## Iterative deepening and stop
+
+`search` loops `depth = 1..=max_depth`, calling the root search each time. After a
+*completed* depth it keeps the result. The `Searcher` carries a `nodes` counter
+and a `deadline`; every ~2048 nodes it checks `should_stop()` (past the deadline),
+which sets `stopped`. A stopped search unwinds and the loop **discards the
+half-finished iteration**, returning the deepest completed result. A found forced
+mate ends the loop early.
+
+## Time budget
+
+| Input | Budget |
+|---|---|
+| `movetime M` | `M − overhead` |
+| clock (`wtime`/`btime` …) | `remaining/movestogo` (or `remaining/30` in sudden death) `+ 0.7·increment`, capped at `0.4·remaining`, minus overhead |
+| `depth D` only | no deadline; deepen to `D` |
+| bare `go` | no deadline; default depth (with the endgame boost), keeping the acceptance test fast |
+
+`overhead` is a small constant (~50 ms) so the engine never flags. The side to
+move picks its own clock: `wtime`/`winc` for White, `btime`/`binc` for Black.
+
+## Transposition-table fix
+
+Today a probe returns an entry only when its depth equals the requested depth, so
+iterative deepening cannot reuse shallower work. Two changes:
+
+1. **Probe on key match.** `get` returns the entry whenever the Zobrist key
+   matches. The depth check moves into the search: a stored entry with
+   `depth ≥ requested` yields the cutoff (`Exact` → return; `LowerBound`/`UpperBound`
+   → tighten alpha/beta).
+2. **Hash-move ordering.** The stored best Move is searched **first**, even when the
+   entry is too shallow to cut. This is what makes re-searching from depth 1 cheap.
+
+## Mate-distance scoring
+
+Checkmate scores `MATE − ply` (ply = distance from the root) instead of flat
+`MATE`, so a mate in one outscores a mate in three. A score is a mate score when
+its magnitude exceeds `MATE − MAX_PLY`. The transposition table applies the
+standard ±ply adjustment on store and probe so mate scores stay correct across the
+table. The result converts plies to moves for `mate` (UCI `score mate` is in
+moves, not plies).
+
+## Principal variation
+
+A triangular PV-table collects the line: at a node that raises alpha, the node's PV
+becomes its move prepended to the best child's PV. The root's line is the principal
+variation; its first move is the returned `move`.
+
+## UCI wrapper
+
+`communication.py` parses `go wtime/btime/winc/binc/movestogo/movetime/depth`,
+translates the tokens to the core's parameters (`wtime` → `white_time_ms`, and so
+on), and calls `search`. It maps the result back to UCI, printing one
+`info depth D score (cp X | mate Y) nodes N time T pv …` line, then
+`bestmove <move>`. Bare `go` keeps the old default depth and endgame boost. The
+command set is unchanged. The HTTP API is unchanged.
+
+## Naming
+
+UCI tokens are an interface detail. They appear only in the UCI wrapper, which
+parses the `go` line and prints `info`. The core and its seam use expressive names
+per the repo's clean-code standard; the wrapper translates between the two layers.
+
+| UCI interface (wrapper only) | Core / seam name |
+|---|---|
+| `go wtime` / `btime` | `white_time_ms` / `black_time_ms` |
+| `go winc` / `binc` | `white_increment_ms` / `black_increment_ms` |
+| `go movetime` | `move_time_ms` |
+| `go movestogo` | `moves_to_go` |
+| `go depth` | `max_depth` |
+| `info score cp` | `score_centipawns` |
+| `info score mate` | `mate_in_moves` (signed moves) |
+| `info time` | `elapsed_ms` |
+| `info pv` | `principal_variation` |
+| `info depth` / `nodes` | `depth` / `nodes` |
+| `bestmove` | `best_move` |
+
+The underlying concepts carry their domain provenance, recorded in the glossary in
+Wave 7: iterative deepening, triangular PV-table, mate score, and centipawn from the
+Chess Programming Wiki; the UCI time controls from the UCI protocol. `SearchLimits`
+follows Stockfish's `LimitsType`. The existing **Principal variation** glossary
+entry loses "(planned)"; its id becomes `principal_variation` (UCI wire token `pv`),
+and `pline` moves to the debt column.
+
+## Naming cleanups in `search.rs`
+
+Apply these when the search functions are rewritten (Waves 1, 3, 4); the existing
+cargo gate covers them.
+
+| Now | New | Why |
+|---|---|---|
+| `checked` | `in_check` | boolean reads as a question; matches the `in_check()` helper |
+| `alpha_orig` | `original_alpha` | no abbreviation |
+| `max_val` | `best_score` | what it is, not how it's computed |
+| `child` | `child_score` | it is a score; aligns with `capture_tree`'s `child_value` |
+| `move_eval` | `move_score` | consistent with `best_score` / `child_score` |
+| `key` | `zobrist_key` | `key` alone is generic at the call sites |
+| `sign` | `perspective` | the side-to-move multiplier |
+
+`stand_pat` stays (the Chess Programming Wiki term for the quiescence static eval)
+with a one-line doc. `negamax` gains a named result type once it carries the
+principal variation and score (Wave 4). `NULL_MOVE` (`"0000"`) stays in the core,
+consistent with the UCI move strings it already returns.
+
+## Alternatives considered
+
+- **TT-based PV** (follow stored best moves). Rejected: a collision or overwrite
+  truncates the line; the triangular table is robust.
+- **UCI tokens as the seam names** (`wtime`, `pv`, `cp`). Rejected: the protocol's
+  terse tokens are an interface detail; the core reads more clearly with expressive
+  names, and the wrapper is the right place to translate.
+- **Adaptive timing** (spend more when the best move is unstable). Deferred: more
+  tuning; the clock fraction is the safe first version.
+- **Per-iteration `info` streaming.** Deferred: needs a PyO3 callback; one final
+  `info` line satisfies lichess-bot.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Time check too coarse and the engine flags | Poll every ~2048 nodes; keep a 50 ms overhead; cap at 40%. |
+| Mate-score TT adjustment is a classic bug source | A unit test asserts a faster mate outscores a slower one and survives a TT round-trip. |
+| Tactical moves shift under new ordering/scoring | Re-run the four tactical tests; a faster mate is an allowed improvement, recorded if a move changes. |
+| Partial-iteration result leaks into the move | The loop only adopts a result from a depth that completed before `stopped`. |

--- a/roadmap/specs/iterative-deepening/requirements.md
+++ b/roadmap/specs/iterative-deepening/requirements.md
@@ -3,7 +3,7 @@ title: Iterative deepening — requirements
 description: User stories and EARS acceptance criteria for iterative deepening, time management, and principal variation on the Rust Searcher.
 ---
 
-> **Status:** Planned (2026-06-15) — tracked on the [board](../../ROADMAP.md).
+> **Status:** Done (2026-06-15) — tracked on the [board](../../ROADMAP.md).
 
 # Iterative deepening — requirements
 

--- a/roadmap/specs/iterative-deepening/requirements.md
+++ b/roadmap/specs/iterative-deepening/requirements.md
@@ -1,0 +1,73 @@
+---
+title: Iterative deepening — requirements
+description: User stories and EARS acceptance criteria for iterative deepening, time management, and principal variation on the Rust Searcher.
+---
+
+> **Status:** Planned (2026-06-15) — tracked on the [board](../../ROADMAP.md).
+
+# Iterative deepening — requirements
+
+Replace fixed-depth search with iterative deepening on the Rust `Searcher`:
+deepen one ply at a time within a time budget derived from the clock, report the
+principal variation, and stop on the budget. Two enabling fixes ride along: the
+transposition table must reuse work across depths, and mate scores must carry
+their distance to the root. Vocabulary follows the UCI protocol and the Chess
+Programming Wiki (see `design.md`).
+
+## Story 1 — Time-managed iterative deepening
+
+As the bot on lichess, I want to search within a budget derived from the clock,
+so I use my time well and never flag.
+
+- AC-1.1 WHEN `search` runs with a `movetime` budget, THE SYSTEM SHALL stop within `movetime` plus a fixed overhead and return a legal Move.
+- AC-1.2 WHEN a clock budget is computed, THE SYSTEM SHALL allocate `remaining/movestogo` (or `remaining/30` in sudden death) plus `0.7 × increment`, never exceeding 40% of the side-to-move's remaining time.
+- AC-1.3 WHEN the budget expires during an iteration, THE SYSTEM SHALL discard that iteration and return the deepest fully completed result.
+- AC-1.4 WHEN `search` is given a `max_depth` and no clock or `movetime`, THE SYSTEM SHALL deepen iteratively to `max_depth` and stop.
+- AC-1.5 WHEN the same position is searched with more time, THE SYSTEM SHALL reach a depth at least as great as a shorter search.
+- AC-1.6 WHEN `search` returns, THE SYSTEM SHALL report `best_move`, `score_centipawns` or `mate_in_moves`, `depth`, `nodes`, `elapsed_ms`, and `principal_variation`.
+
+## Story 2 — Transposition-table reuse across depths
+
+As the engine, I want the table to serve any entry searched at least as deep and
+to seed move ordering, so each iteration reuses the last one's work.
+
+- AC-2.1 WHEN a position is probed and a stored entry's depth is at least the requested depth, THE SYSTEM SHALL use it for an exact cutoff or to tighten alpha/beta.
+- AC-2.2 WHEN a stored entry exists for the position, THE SYSTEM SHALL search its stored best Move first, even when the entry is too shallow to cut.
+- AC-2.3 WHEN a depth-`D` search runs with the table populated by the depth-`D-1` iteration, THE SYSTEM SHALL visit fewer nodes than the same search with an empty table.
+
+## Story 3 — Mate-distance scoring
+
+As an analyst, I want forced mates scored by distance, so the engine prefers the
+fastest mate and reports it correctly.
+
+- AC-3.1 WHEN two moves both force mate, THE SYSTEM SHALL prefer the one mating in fewer moves.
+- AC-3.2 WHEN the engine reports a forced mate, THE SYSTEM SHALL report `mate_in_moves` as the number of moves to mate (positive when the side to move gives mate, negative when it is mated); the UCI wrapper prints this as `score mate`.
+- AC-3.3 WHEN a mate score is stored to or read from the transposition table, THE SYSTEM SHALL adjust it by the distance from the root so it stays correct.
+
+## Story 4 — Principal variation
+
+As an analyst, I want the engine to report the line it expects, so I can see its
+plan.
+
+- AC-4.1 WHEN `search` completes a depth, THE SYSTEM SHALL produce a principal variation whose first Move equals the returned Move.
+- AC-4.2 WHEN `search` reports a principal variation, THE SYSTEM SHALL produce a legal sequence of Moves from the searched position.
+
+## Story 5 — UCI time controls
+
+As lichess-bot, I want `go` with a clock or `movetime` to drive the search, so the
+engine plays timed games.
+
+- AC-5.1 WHEN the engine receives `go wtime W btime B` with optional `winc`, `binc`, and `movestogo`, THE SYSTEM SHALL search within the computed budget and reply `bestmove`.
+- AC-5.2 WHEN the engine receives `go movetime M`, THE SYSTEM SHALL search about `M` ms and reply `bestmove`.
+- AC-5.3 WHEN the engine receives `go depth D`, THE SYSTEM SHALL deepen to `D` and reply `bestmove`.
+- AC-5.4 WHEN the engine receives bare `go`, THE SYSTEM SHALL search to a default depth and reply `bestmove`.
+- AC-5.5 WHEN a search completes, THE SYSTEM SHALL print one `info depth D score (cp X | mate Y) nodes N time T pv ...` line before `bestmove`.
+
+## Story 6 — Behavior preserved
+
+As the maintainer, I want the tactics and contracts intact, so the upgrade adds
+strength without regressing.
+
+- AC-6.1 WHEN searched to depth 3, THE SYSTEM SHALL still return `f8f7`, `h7h8`, `f6a6`, and not `e1e8` for the four tactical positions.
+- AC-6.2 WHEN the engine accepts UCI commands, THE SYSTEM SHALL recognize exactly `uci`, `isready`, `ucinewgame`, `position`, `go`, `quit`.
+- AC-6.3 WHEN a move is requested over either entrypoint, THE SYSTEM SHALL return a legal Move.

--- a/roadmap/specs/iterative-deepening/tasks.md
+++ b/roadmap/specs/iterative-deepening/tasks.md
@@ -1,0 +1,73 @@
+---
+title: Iterative deepening — tasks
+description: Waved implementation plan; each task names the gate that proves it.
+---
+
+> **Status:** Planned (2026-06-15) — tracked on the [board](../../ROADMAP.md).
+
+# Iterative deepening — tasks
+
+Tasks within a wave are independent; each wave builds on the last. Every task
+names its gate. The enabling fixes (Wave 1) land before iterative deepening
+relies on them. Apply the `search.rs` naming cleanups (see design.md) as those
+functions are rewritten across Waves 1, 3, and 4.
+
+## Wave 1 — Enabling fixes
+
+- **1.1 Transposition-table reuse.** `get` returns on a Zobrist-key match; the
+  search uses a stored entry with `depth ≥ requested` for the cutoff and always
+  searches the stored best Move first. *Gate: AC-2.1–2.3 — a unit test shows a
+  deep entry cuts, and a depth-`D` search with a warm table visits fewer nodes
+  than with an empty one.*
+- **1.2 Mate-distance scoring.** Score checkmate `MATE − ply`; classify mate
+  scores; apply the ±ply adjustment on TT store and probe. *Gate: AC-3.1, AC-3.3
+  — a mate in one outscores a mate in three and survives a TT round-trip.*
+
+## Wave 2 — Time budget
+
+- **2.1 `SearchLimits` + budget.** Parse limits into `SearchLimits`; compute the
+  deadline from `movetime`, the clock (`remaining/movestogo` or `/30`, `+0.7·inc`,
+  capped at 40%, minus overhead), or none for depth-only. *Gate: AC-1.2 — unit
+  tests on the budget for movetime, sudden death, increment, `movestogo`, and the
+  40% cap.*
+
+## Wave 3 — Iterative deepening loop
+
+- **3.1 Node counter + stop.** Add the `nodes` counter and `should_stop()` polled
+  every ~2048 nodes against the deadline. *Gate: AC-1.1 — a `movetime` search
+  returns within budget + overhead.*
+- **3.2 Deepening loop.** Loop `1..=max_depth`, keep the last completed depth,
+  discard a stopped iteration, early-exit on forced mate. *Gate: AC-1.3–1.5 — the
+  result deepens with more time and never adopts a half-finished iteration.*
+
+## Wave 4 — Principal variation
+
+- **4.1 Triangular PV-table.** Collect the PV; expose it on the result. *Gate:
+  AC-4.1–4.2 — the PV's first Move equals the returned Move and the line is legal.*
+
+## Wave 5 — The `search` seam
+
+- **5.1 PyO3 `search`.** Expose `search(max_depth, move_time_ms, white_time_ms,
+  black_time_ms, white_increment_ms, black_increment_ms, moves_to_go)` returning
+  the result dict (`best_move`, `score_centipawns`, `mate_in_moves`, `depth`,
+  `nodes`, `elapsed_ms`, `principal_variation`); `mate_in_moves` signed. *Gate:
+  AC-1.6, AC-3.2 — a Python call returns the documented shape with `mate_in_moves`
+  in moves.*
+
+## Wave 6 — UCI wrapper
+
+- **6.1 Scenario first.** Add a UCI process Scenario to `features/`: `go movetime`
+  returns a `bestmove` and an `info … pv …` line. *Gate: Scenario exists and fails.*
+- **6.2 Wire `communication.py`.** Parse the `go` time-control tokens, call
+  `search`, print the `info` line then `bestmove`; bare `go` keeps the default
+  depth and endgame boost. *Gate: AC-5.1–5.5 — acceptance Scenarios pass through
+  the real UCI engine.*
+
+## Wave 7 — Verify & docs
+
+- **7.1 Tactics preserved.** Run the four tactical tests through `search` at depth
+  3. *Gate: AC-6.1 — `f8f7`, `h7h8`, `f6a6`, not `e1e8`; a changed move is recorded
+  as a faster-mate improvement.*
+- **7.2 Docs & board.** Update `knowledge/glossary.md` (new terms + provenance, and
+  the Principal variation entry), note the seam, move the Epic 1 cards to Done.
+  *Gate: `python3 scripts/knowledge.py check` clean; recorded gate PASS.*

--- a/roadmap/specs/iterative-deepening/tasks.md
+++ b/roadmap/specs/iterative-deepening/tasks.md
@@ -3,7 +3,7 @@ title: Iterative deepening — tasks
 description: Waved implementation plan; each task names the gate that proves it.
 ---
 
-> **Status:** Planned (2026-06-15) — tracked on the [board](../../ROADMAP.md).
+> **Status:** Done (2026-06-15) — tracked on the [board](../../ROADMAP.md).
 
 # Iterative deepening — tasks
 

--- a/src/communication.py
+++ b/src/communication.py
@@ -3,6 +3,17 @@ import sys
 
 import brandobot_core
 
+# UCI `go` token -> core search parameter. UCI tokens live only here.
+GO_PARAMETERS = {
+    "depth": "max_depth",
+    "movetime": "move_time_ms",
+    "wtime": "white_time_ms",
+    "btime": "black_time_ms",
+    "winc": "white_increment_ms",
+    "binc": "black_increment_ms",
+    "movestogo": "moves_to_go",
+}
+
 
 def talk():
     """The UCI input/output loop — a slice of the protocol that delegates all
@@ -42,9 +53,54 @@ def command(searcher, depth, message):
         return
 
     if message.startswith("go"):
-        search_depth = depth + 4 if brandobot_core.is_endgame(searcher.fen()) else depth
-        print(f"bestmove {searcher.next_move(search_depth)}")
+        go(searcher, depth, message)
         return
+
+
+def go(searcher, default_depth, message):
+    """Run a search for a `go` command and report `info` then `bestmove`."""
+    limits = parse_go(message)
+    if limits is None:
+        # Bare `go`: a fixed default depth, deeper in the endgame as before.
+        boost = 4 if brandobot_core.is_endgame(searcher.fen()) else 0
+        result = searcher.search(max_depth=default_depth + boost)
+    else:
+        result = searcher.search(**limits)
+
+    print(info_line(result))
+    print(f"bestmove {result['best_move']}")
+
+
+def parse_go(message):
+    """Translate the `go` time-control tokens into core search parameters, or
+    None for a bare `go` (or one with no recognized limits)."""
+    tokens = message.split()[1:]
+    limits = {}
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if token in GO_PARAMETERS and index + 1 < len(tokens):
+            try:
+                limits[GO_PARAMETERS[token]] = int(tokens[index + 1])
+            except ValueError:
+                pass
+            index += 2
+        else:
+            index += 1
+    return limits or None
+
+
+def info_line(result):
+    """Format a search result as a UCI `info` line."""
+    if result["mate_in_moves"] is not None:
+        score = f"mate {result['mate_in_moves']}"
+    else:
+        score = f"cp {result['score_centipawns']}"
+    pv = " ".join(result["principal_variation"])
+    return (
+        f"info depth {result['depth']} score {score} "
+        f"nodes {result['nodes']} time {result['elapsed_ms']} pv {pv}"
+    )
 
 
 def set_position(searcher, message):
@@ -68,6 +124,6 @@ def set_position(searcher, message):
 
 def parse_depth():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--depth", default=3, help="search depth (default: 3)")
+    parser.add_argument("--depth", default=3, help="default search depth (default: 3)")
     args, _ = parser.parse_known_args()
     return int(args.depth)

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -67,3 +67,20 @@ def returns_legal_move(uci_session):
     assert match, uci_session["stdout"]
     move = match.group(1)
     assert chess.Move.from_uci(move) in chess.Board().legal_moves
+
+
+@when(parsers.parse('it searches the start position with "{go_args}"'))
+def search_position(uci_session, go_args):
+    result = run_engine(f"position startpos\ngo {go_args}\nquit\n")
+    uci_session["stdout"] = result.stdout
+    uci_session["returncode"] = result.returncode
+
+
+@then("it reports a principal variation")
+def reports_principal_variation(uci_session):
+    assert uci_session["returncode"] == 0, uci_session
+    info_lines = [
+        line for line in uci_session["stdout"].splitlines() if line.startswith("info")
+    ]
+    assert info_lines, uci_session["stdout"]
+    assert any(" pv " in line for line in info_lines), uci_session["stdout"]


### PR DESCRIPTION
## Summary

This PR replaces fixed-depth search with iterative deepening on the Rust Searcher.
The engine now deepens one ply at a time within a time budget, reuses the
transposition table across depths, reports the principal variation, and scores
mates by distance. The spec lives in `roadmap/specs/iterative-deepening/`.

## Motivation

The engine searched a fixed depth regardless of the clock, so it could not spend
its time well or play timed games. Iterative deepening turns the clock into a
per-move budget and uses all available time to search deeper, which raises move
quality and unlocks UCI time controls, the prerequisite for real lichess play.
The transposition-table fix is what makes deepening cheap: re-searching from depth
1 reuses each prior iteration's work.

## What Changed

- The Searcher deepens `1..max_depth` against a deadline and returns
  `{best_move, score_centipawns or mate_in_moves, depth, nodes, elapsed_ms,
  principal_variation}`. A half-finished iteration is discarded; the last
  completed depth is returned.
- Time budget from the clock: `remaining/movestogo` (or `/30` in sudden death)
  plus `0.7 * increment`, capped at 40%, honoring `movetime` and `depth`.
- Transposition table: a probe returns any key match; a deeper-or-equal entry
  cuts, and the stored best move is tried first. A warm table cuts node counts.
- Mate-distance scoring: a checkmate scores `MATE - ply`, so a faster mate wins;
  mate scores carry the standard ply adjustment across the table and report as
  UCI `score mate` (in moves).
- Principal variation via a triangular table.
- The UCI wrapper parses `go wtime/btime/winc/binc/movetime/movestogo/depth`,
  prints an `info` line, then `bestmove`. UCI tokens stay in the wrapper; the core
  uses expressive names, translated at the boundary.
- `search.rs` naming cleanups (`in_check`, `original_alpha`, `best_score`,
  `child_score`, `move_score`, `zobrist_key`, `perspective`).

## Tests

- 30 cargo tests and 20 pytest, plus ruff, clippy with `-D warnings`, and the
  knowledge check. The pre-push hook ran the gate before this branch was pushed.
- New: time-budget unit tests (movetime, sudden death, increment, movestogo, the
  40% cap); the deepening loop reaches the requested depth and a tiny budget still
  returns a move; the PV first move equals the best move and the line is legal; a
  faster mate scores higher and reports mate in 1 versus 3; a warm table visits
  fewer nodes than a cold one; and a UCI `go movetime` scenario reports an
  `info … pv …` line and `bestmove`.
- The four tactical tests are unchanged: `f8f7`, `h7h8`, `f6a6`, and not `e1e8`.

To run it: install a Rust toolchain (https://rustup.rs), then
`.venv/bin/maturin develop --release -m core/Cargo.toml` and `scripts/check-fast.sh`.
