### PR TITLE
Strength-measurement harness: EPD tactical suite and self-play Elo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,8 @@ scripts/check-fast.sh            # canonical gate: cargo fmt/clippy/test + matur
 .venv/bin/python src/main.py     # run the UCI engine (type: uci, isready, go, quit)
 .venv/bin/python src/api.py      # run the Flask HTTP API
 .venv/bin/python src/perft.py    # move-generation benchmark
+.venv/bin/python scripts/epd_suite.py --movetime 100 bench/wac.epd  # tactical solve-rate
+.venv/bin/python scripts/selfplay.py --games 100 --depth 4          # self-play Elo
 scripts/board.sh                 # render the kanban board from roadmap/ROADMAP.md
 ```
 

--- a/bench/openings.epd
+++ b/bench/openings.epd
@@ -1,0 +1,10 @@
+# Balanced opening positions for self-play variety, a few plies into common
+# openings. One FEN per line; each is played once with each color.
+r1bqkbnr/pppp1ppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 2 3
+r1bqkbnr/pppp1ppp/2n5/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R b KQkq - 3 3
+rnbqkbnr/pp1ppppp/8/2p5/4P3/8/PPPP1PPP/RNBQKBNR w KQkq c6 0 2
+rnbqkbnr/pppp1ppp/4p3/8/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2
+rnbqkbnr/pp1ppppp/2p5/8/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2
+rnbqkbnr/ppp2ppp/4p3/3p4/2PP4/8/PP2PPPP/RNBQKBNR w KQkq - 0 3
+rnbqkb1r/pppppppp/5n2/8/3P4/8/PPP1PPPP/RNBQKBNR w KQkq - 1 2
+rnbqkbnr/pppppppp/8/8/2P5/8/PP1PPPPP/RNBQKBNR b KQkq c3 0 1

--- a/bench/wac.epd
+++ b/bench/wac.epd
@@ -1,0 +1,14 @@
+# Win At Chess (WAC) — a sample of the standard tactical test suite by Fred
+# Reinfeld, long distributed in the computer-chess community as EPD. Each line is
+# a position with a `bm` (best move) operation. This is a 10-position sample;
+# point the runner at a fuller WAC.epd for the complete 300-position suite.
+2rr3k/pp3pp1/1nnqbN1p/3pN3/2pP4/2P3Q1/PPB4P/R4RK1 w - - bm Qg6; id "WAC.001";
+8/7p/5k2/5p2/p1p2P2/Pr1pPK2/1P1R3P/8 b - - bm Rxb2; id "WAC.002";
+5rk1/1ppb3p/p1pb4/6q1/3P1p1r/2P1R2P/PP1BQ1P1/5RKN w - - bm Rg3; id "WAC.003";
+r1bq2rk/pp3pbp/2p1p1pQ/7P/3P4/2PB1N2/PP3PP1/2KR3R w - - bm Qxh7+; id "WAC.004";
+5k2/6pp/p1qN4/1p1p4/3P4/2PKP2Q/PP3r2/3R4 b - - bm Qc4+; id "WAC.005";
+7k/p7/1R5K/6r1/6p1/6P1/8/8 w - - bm Rb7; id "WAC.006";
+rnbqkb1r/pppp1ppp/8/4P3/6n1/7P/PPPNPPP1/R1BQKBNR b KQkq - bm Ne3; id "WAC.007";
+r4q1k/p2bR1rp/2p2Q1N/5p2/5p2/2P5/PP3PPP/R5K1 w - - bm Rf7; id "WAC.008";
+3q1rk1/p4pp1/2pb3p/3p4/6Pr/1PNQ4/P1PB1PP1/4RRK1 b - - bm Bh2+; id "WAC.009";
+2br2k1/2q3rn/p2NppQ1/2p1P3/Pp5R/4P3/1P3PPP/3R2K1 w - - bm Rxh7; id "WAC.010";

--- a/knowledge/glossary.md
+++ b/knowledge/glossary.md
@@ -63,9 +63,14 @@ field, and record must fit. The chess logic lives in the Rust core
 | Perft | Performance test — counts leaf nodes to a depth to validate move generation | `perft(fen, depth)` | |
 | Endgame | Late-game phase that triggers deeper search | `Board::is_endgame` | |
 | brandobot_core | The Rust engine core exposed to Python as a PyO3 module | `import brandobot_core` | |
+| EPD | Extended Position Description — a FEN plus operations such as `bm` (best move) | `bench/wac.epd` | |
+| Solve-rate | The fraction of EPD positions whose searched move matches a `bm` move | `epd_suite.py` | |
+| Self-play | Two engine builds playing a match to compare strength | `selfplay.py` | |
+| Elo | A rating-difference estimate from a match's score rate | `selfplay.py` | |
 
 Bitboard, magic bitboard, make/unmake, piece-square table, negamax, iterative
 deepening, the triangular PV-table, mate scores, and the centipawn follow
-[Chess Programming Wiki](https://www.chessprogramming.org/) conventions; perft and
-MVV-LVA already did. The time-control tokens are UCI; `SearchLimits` follows
-Stockfish's `LimitsType`. `brandobot_core` is this repo's PyO3 module name.
+[Chess Programming Wiki](https://www.chessprogramming.org/) conventions; perft,
+MVV-LVA, EPD, Elo, and self-play already did. The time-control tokens are UCI;
+`SearchLimits` follows Stockfish's `LimitsType`. `brandobot_core` is this repo's
+PyO3 module name.

--- a/roadmap/ROADMAP.md
+++ b/roadmap/ROADMAP.md
@@ -76,3 +76,16 @@ principal variation. Improves move quality and enables timed play on lichess.
 | Principal variation (triangular PV-table) (@branransom) | Done | [iterative-deepening](specs/iterative-deepening/design.md) | Iterative-deepening loop + stop |
 | Time-aware `search` seam (PyO3) (@branransom) | Done | [iterative-deepening](specs/iterative-deepening/design.md) | Principal variation (triangular PV-table) |
 | UCI time controls (`go` + `info pv`) (@branransom) | Done | [iterative-deepening](specs/iterative-deepening/design.md) | Time-aware `search` seam (PyO3) |
+
+### Epic 2 — Strength measurement
+
+Turn engine changes into a measured strength delta: an EPD tactical suite that
+reports a solve-rate and a self-play match that reports an Elo estimate, with
+python-chess as the independent oracle. Verifies every future search and eval
+change instead of guessing.
+
+| Work | Status | Spec | Depends on |
+|---|---|---|---|
+| EPD tactical suite (solve-rate) | Planned | [strength-harness](specs/strength-harness/design.md) | Iterative deepening |
+| Self-play match (Elo) | Planned | [strength-harness](specs/strength-harness/design.md) | Iterative deepening |
+| Gate self-test + docs | Planned | [strength-harness](specs/strength-harness/design.md) | EPD tactical suite (solve-rate), Self-play match (Elo) |

--- a/roadmap/ROADMAP.md
+++ b/roadmap/ROADMAP.md
@@ -86,6 +86,6 @@ change instead of guessing.
 
 | Work | Status | Spec | Depends on |
 |---|---|---|---|
-| EPD tactical suite (solve-rate) | Planned | [strength-harness](specs/strength-harness/design.md) | Iterative deepening |
-| Self-play match (Elo) | Planned | [strength-harness](specs/strength-harness/design.md) | Iterative deepening |
-| Gate self-test + docs | Planned | [strength-harness](specs/strength-harness/design.md) | EPD tactical suite (solve-rate), Self-play match (Elo) |
+| EPD tactical suite (solve-rate) (@branransom) | Done | [strength-harness](specs/strength-harness/design.md) | Iterative deepening |
+| Self-play match (Elo) (@branransom) | Done | [strength-harness](specs/strength-harness/design.md) | Iterative deepening |
+| Gate self-test + docs (@branransom) | Done | [strength-harness](specs/strength-harness/design.md) | EPD tactical suite (solve-rate), Self-play match (Elo) |

--- a/roadmap/specs/strength-harness/design.md
+++ b/roadmap/specs/strength-harness/design.md
@@ -1,0 +1,108 @@
+---
+title: Strength harness — design
+description: Architecture for the EPD tactical suite and self-play match harness, with python-chess as the independent oracle.
+---
+
+> **Status:** Planned (2026-06-15) — tracked on the [board](../../ROADMAP.md).
+
+# Strength harness — design
+
+## Decision summary
+
+| Decision | Choice | Why |
+|---|---|---|
+| Metrics | EPD solve-rate + self-play Elo | Fast tactical regression and a real strength number. |
+| A/B method | Two UCI engine commands | General and decoupled from build management; mirrors cutechess. |
+| Oracle | `python-chess` | The suite's moves and the game arbiter share no code with the engine. |
+| Dependencies | None new | `python-chess` (a test dep) supplies EPD parsing, SAN↔UCI, and the UCI driver. |
+| Gate | On-demand; tiny self-test | Full runs are slow; a fast self-test guards the tools. |
+
+## Components
+
+Two scripts in `scripts/`, on-demand like `bench_perft.py`.
+
+### `epd_suite.py` — tactical solve-rate
+
+Loads an EPD file, searches each position at a fixed `movetime` or `depth`, and
+reports the solve-rate. Runs `brandobot_core` in-process for speed.
+`python-chess` parses the EPD and converts each position's `bm` (SAN) to UCI for
+comparison.
+
+```
+python scripts/epd_suite.py --movetime 100 bench/wac.epd
+→ 247/300 solved (82.3%); 53 failed (listed)
+```
+
+### `selfplay.py` — match and Elo
+
+Takes two UCI player commands, plays `N` games, and reports the result and an Elo
+estimate. `python-chess`'s `chess.engine.SimpleEngine` runs each engine as a UCI
+subprocess; `python-chess` is the **arbiter** (legality, draws, adjudication).
+
+```
+# build the baseline in a worktree, then:
+python scripts/selfplay.py --games 200 --movetime 100 \
+  --engine1 "python src/main.py" --engine2 "python ../base/src/main.py"
+→ engine1 vs engine2: +58 -41 =101, 54.2%, Elo +29 ± 24
+```
+
+Each opening is played twice, colors swapped, for fairness. `--depth` gives
+deterministic games; `--movetime` gives timed play. A seed fixes opening order.
+
+## Elo estimate
+
+`score = (wins + 0.5·draws) / games`; `elo = -400 · log10(1/score − 1)` (clamped
+away from 0 and 1). The error margin is the standard ±1.96·σ from the score
+variance. It is the conventional fixed-rating-difference estimate, not SPRT (a
+possible later addition).
+
+## Data
+
+| File | Contents |
+|---|---|
+| `bench/wac.epd` | A sample of the Win At Chess tactical suite (Fred Reinfeld), a standard public test set; the runner accepts any EPD file for fuller suites |
+| `bench/openings.epd` | Balanced opening positions for self-play variety |
+
+## Independent verification
+
+The engine is the system under test; the referee is not. EPD best moves are
+external ground truth, and `python-chess` adjudicates games. Neither shares code
+with `brandobot_core`, satisfying the repo's independent-verification rule.
+
+## Gate
+
+The full suite and matches are manual. A fast pytest self-test runs `epd_suite`
+on a two-position mini-EPD and `selfplay` on a single shallow game, asserting each
+reports its summary — guarding the tools without slowing the gate.
+
+## Naming and provenance
+
+New domain terms, recorded in the glossary:
+
+| Term | Definition | Provenance |
+|---|---|---|
+| EPD | Extended Position Description — a FEN with operations such as `bm` (best move) | the EPD standard / CPW |
+| Elo | A rating-difference estimate from a match's score rate | Arpad Elo / CPW "Match Statistics" |
+| Solve-rate | The fraction of EPD positions whose searched move matches a `bm` move | this repo |
+| Self-play | Two engine builds playing a match to compare strength | CPW "Engine Testing" |
+
+CLI flags reuse the established names (`--movetime`, `--depth`, `--games`); the
+engine commands are opaque strings, so no UCI tokens leak into the harness.
+
+## Alternatives considered
+
+- **External arbiter (fastchess / cutechess-cli) with SPRT.** More rigorous, but
+  adds a binary dependency; deferred. The in-repo harness can grow SPRT later.
+- **Feature-flag A/B in one build.** Rejected: every change would need a flag and
+  the engine would gain option plumbing; two commands stay general.
+- **EPD only.** Rejected: it measures tactics, not overall strength, and gives no
+  Elo.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Timed games are nondeterministic | `--depth` mode is deterministic; document it for reproducible A/B. |
+| Self-play subprocess startup is slow | Self-test uses one shallow game; full matches are manual and use short time controls. |
+| Suite licensing | Bundle a small attributed WAC sample; accept any external EPD path for fuller suites. |
+| Elo from few games is noisy | Report the error margin; document that hundreds of games are needed for small deltas. |

--- a/roadmap/specs/strength-harness/design.md
+++ b/roadmap/specs/strength-harness/design.md
@@ -3,7 +3,7 @@ title: Strength harness — design
 description: Architecture for the EPD tactical suite and self-play match harness, with python-chess as the independent oracle.
 ---
 
-> **Status:** Planned (2026-06-15) — tracked on the [board](../../ROADMAP.md).
+> **Status:** Done (2026-06-15) — tracked on the [board](../../ROADMAP.md).
 
 # Strength harness — design
 

--- a/roadmap/specs/strength-harness/requirements.md
+++ b/roadmap/specs/strength-harness/requirements.md
@@ -1,0 +1,49 @@
+---
+title: Strength harness — requirements
+description: User stories and EARS acceptance criteria for an EPD tactical suite and a self-play match harness that measure engine strength.
+---
+
+> **Status:** Planned (2026-06-15) — tracked on the [board](../../ROADMAP.md).
+
+# Strength harness — requirements
+
+Two on-demand tools that turn engine changes into a measured strength delta: an
+EPD tactical suite that reports a solve-rate, and a self-play match that reports
+an Elo estimate. Both use `python-chess` as the independent oracle — the suite's
+known best moves and the game arbiter share no code with the engine.
+
+## Story 1 — EPD tactical suite
+
+As the maintainer, I want a solve-rate on a tactical suite, so any change shows a
+tactical-strength delta.
+
+- AC-1.1 WHEN `epd_suite.py` runs on an EPD file at a fixed `movetime` or `depth`, THE SYSTEM SHALL report the number solved, the total, and the solve-rate.
+- AC-1.2 WHEN a position's searched best move is among that position's EPD `bm` moves, THE SYSTEM SHALL count it solved.
+- AC-1.3 WHEN a position is not solved, THE SYSTEM SHALL list it with its FEN, the expected moves, and the move played.
+- AC-1.4 WHEN given a path to any EPD file, THE SYSTEM SHALL run that file, so a fuller suite can be supplied.
+
+## Story 2 — Self-play match
+
+As the maintainer, I want two engine commands to play a match with an Elo
+estimate, so I can measure whether a change is stronger.
+
+- AC-2.1 WHEN `selfplay.py` runs with two UCI engine commands for `N` games, THE SYSTEM SHALL play `N` games, alternating colors, and report wins, losses, and draws from the first engine's view.
+- AC-2.2 WHEN the match completes, THE SYSTEM SHALL report the score rate and an Elo estimate with an error margin.
+- AC-2.3 WHEN `--depth` is given, THE SYSTEM SHALL play every game at that fixed depth.
+- AC-2.4 WHEN `--movetime` is given, THE SYSTEM SHALL play at that time per move.
+- AC-2.5 WHEN the match starts, THE SYSTEM SHALL draw openings from a fixed opening list so games vary.
+
+## Story 3 — Independent oracle
+
+As the maintainer, I want the verdicts to come from outside the engine, so the
+measurement is trustworthy.
+
+- AC-3.1 WHEN the harness judges a solved position or a game result, THE SYSTEM SHALL use `python-chess`, not `brandobot_core`.
+
+## Story 4 — On-demand, guarded by a self-test
+
+As the maintainer, I want the slow runs kept out of the fast gate but the tools
+guarded, so the gate stays fast and the harness stays working.
+
+- AC-4.1 WHEN `scripts/check-fast.sh` runs, THE SYSTEM SHALL NOT run the full EPD suite or a self-play match.
+- AC-4.2 WHEN the gate runs, THE SYSTEM SHALL run a fast self-test that exercises both runners on a tiny input.

--- a/roadmap/specs/strength-harness/requirements.md
+++ b/roadmap/specs/strength-harness/requirements.md
@@ -3,7 +3,7 @@ title: Strength harness — requirements
 description: User stories and EARS acceptance criteria for an EPD tactical suite and a self-play match harness that measure engine strength.
 ---
 
-> **Status:** Planned (2026-06-15) — tracked on the [board](../../ROADMAP.md).
+> **Status:** Done (2026-06-15) — tracked on the [board](../../ROADMAP.md).
 
 # Strength harness — requirements
 

--- a/roadmap/specs/strength-harness/tasks.md
+++ b/roadmap/specs/strength-harness/tasks.md
@@ -1,0 +1,41 @@
+---
+title: Strength harness — tasks
+description: Waved plan for the EPD suite and self-play harness; each task names its gate.
+---
+
+> **Status:** Planned (2026-06-15) — tracked on the [board](../../ROADMAP.md).
+
+# Strength harness — tasks
+
+Tasks within a wave are independent; each wave builds on the last. Every task
+names its gate. The two runners (Waves 1 and 2) are independent and could land in
+either order.
+
+## Wave 1 — EPD tactical suite
+
+- **1.1 EPD runner.** `scripts/epd_suite.py`: parse an EPD file with `python-chess`,
+  search each position via `brandobot_core` at a `movetime` or `depth`, compare the
+  move to the `bm` set, and report the solve-rate and the failures. *Gate: AC-1.1–1.4
+  — a self-test runs a two-position mini-EPD and asserts the reported solve-rate.*
+- **1.2 WAC sample.** Add `bench/wac.epd` (an attributed Win At Chess sample) and a
+  header noting provenance. *Gate: the runner solves the sample at a sane depth.*
+
+## Wave 2 — Self-play match
+
+- **2.1 Self-play runner.** `scripts/selfplay.py`: play two UCI engine commands for
+  `N` games via `python-chess`'s engine driver and arbiter, alternating colors from
+  a fixed opening list, and report wins/losses/draws, the score rate, and an Elo
+  estimate with an error margin. *Gate: AC-2.1–2.5 — a self-test plays one shallow
+  game and asserts the reported summary.*
+- **2.2 Openings + Elo.** Add `bench/openings.epd` and the Elo/error-margin
+  computation. *Gate: AC-2.2 — a unit test on the Elo formula for known score rates.*
+
+## Wave 3 — Gate & docs
+
+- **3.1 Gate self-test.** Wire the fast harness self-test into the suite; keep full
+  runs out of `scripts/check-fast.sh`. *Gate: AC-4.1–4.2 — the gate runs the
+  self-test and not the full suite.*
+- **3.2 Docs & board.** Update `knowledge/glossary.md` (EPD, Elo, solve-rate,
+  self-play with provenance), document the tools in `AGENTS.md` Commands, and move
+  the Epic 2 cards to Done. *Gate: `python3 scripts/knowledge.py check` clean;
+  recorded gate PASS.*

--- a/roadmap/specs/strength-harness/tasks.md
+++ b/roadmap/specs/strength-harness/tasks.md
@@ -3,7 +3,7 @@ title: Strength harness — tasks
 description: Waved plan for the EPD suite and self-play harness; each task names its gate.
 ---
 
-> **Status:** Planned (2026-06-15) — tracked on the [board](../../ROADMAP.md).
+> **Status:** Done (2026-06-15) — tracked on the [board](../../ROADMAP.md).
 
 # Strength harness — tasks
 

--- a/scripts/epd_suite.py
+++ b/scripts/epd_suite.py
@@ -1,0 +1,70 @@
+"""EPD tactical suite: search each position and report the solve-rate.
+
+A position is solved when the engine's searched move is among the position's `bm`
+(best-move) operations. python-chess parses the EPD and converts each `bm` from
+SAN to UCI, so the suite's known answers are the independent ground truth.
+
+    python scripts/epd_suite.py --movetime 100 bench/wac.epd
+"""
+
+import argparse
+
+import chess
+
+import brandobot_core
+
+
+def solved_move(searcher, fen, movetime, depth):
+    """Search `fen` and return the engine's best move in UCI."""
+    searcher.set_fen(fen)
+    if depth is not None:
+        return searcher.search(max_depth=depth)["best_move"]
+    return searcher.search(move_time_ms=movetime)["best_move"]
+
+
+def run(epd_lines, movetime=None, depth=None):
+    """Return (solved, total, failures) for the EPD lines. Each failure is
+    (fen, expected_uci_moves, played_uci)."""
+    searcher = brandobot_core.Searcher()
+    solved = 0
+    total = 0
+    failures = []
+    for line in epd_lines:
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        board = chess.Board()
+        operations = board.set_epd(line)
+        best_moves = operations.get("bm")
+        if not best_moves:
+            continue
+        total += 1
+        expected = sorted(move.uci() for move in best_moves)
+        played = solved_move(searcher, board.fen(), movetime, depth)
+        if played in expected:
+            solved += 1
+        else:
+            failures.append((board.fen(), expected, played))
+    return solved, total, failures
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run an EPD tactical suite.")
+    parser.add_argument("epd_file", help="path to an EPD file")
+    parser.add_argument("--movetime", type=int, help="milliseconds per position")
+    parser.add_argument("--depth", type=int, help="fixed search depth per position")
+    args = parser.parse_args()
+    if args.movetime is None and args.depth is None:
+        args.movetime = 100
+
+    with open(args.epd_file) as epd:
+        solved, total, failures = run(epd, args.movetime, args.depth)
+
+    rate = 100 * solved / total if total else 0.0
+    print(f"{solved}/{total} solved ({rate:.1f}%)")
+    for fen, expected, played in failures:
+        print(f"  FAIL {fen} expected {' '.join(expected)} played {played}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/selfplay.py
+++ b/scripts/selfplay.py
@@ -1,0 +1,152 @@
+"""Self-play match: two UCI engines play a match; report the result and Elo.
+
+python-chess drives each engine as a UCI subprocess and arbitrates the games
+(legality, draws, adjudication), so the referee shares no code with the engine
+under test. Build a baseline in a git worktree to compare against a candidate.
+
+    python scripts/selfplay.py --games 200 --movetime 100 \\
+      --engine1 "python src/main.py" --engine2 "python ../base/src/main.py"
+"""
+
+import argparse
+import math
+import shlex
+import sys
+
+import chess
+import chess.engine
+
+
+def elo_estimate(wins, losses, draws):
+    """Return (elo, margin): the rating difference favoring the first engine and a
+    95% error margin, from the match score."""
+    games = wins + losses + draws
+    if games == 0:
+        return 0.0, 0.0
+    score = (wins + 0.5 * draws) / games
+    if score <= 0.0:
+        return -800.0, 0.0
+    if score >= 1.0:
+        return 800.0, 0.0
+    elo = -400.0 * math.log10(1.0 / score - 1.0)
+    score_variance = (
+        wins * (1.0 - score) ** 2
+        + draws * (0.5 - score) ** 2
+        + losses * (0.0 - score) ** 2
+    ) / games
+    standard_error = math.sqrt(score_variance / games)
+    elo_per_score = 400.0 / (math.log(10.0) * score * (1.0 - score))
+    margin = 1.96 * standard_error * elo_per_score
+    return elo, margin
+
+
+def play_game(white, black, opening_fen, limit, max_moves):
+    """Play one game and return its result string (`1-0`, `0-1`, `1/2-1/2`)."""
+    board = chess.Board(opening_fen)
+    engines = {chess.WHITE: white, chess.BLACK: black}
+    moves = 0
+    while not board.is_game_over(claim_draw=True) and moves < max_moves:
+        played = engines[board.turn].play(board, limit)
+        if played.move is None:
+            break
+        board.push(played.move)
+        moves += 1
+    result = board.result(claim_draw=True)
+    return result if result != "*" else "1/2-1/2"
+
+
+def run_match(engine1_command, engine2_command, openings, games, limit, max_moves):
+    """Play `games` games and return (wins, losses, draws) from engine1's view."""
+    wins = losses = draws = 0
+    with (
+        chess.engine.SimpleEngine.popen_uci(engine1_command) as engine1,
+        chess.engine.SimpleEngine.popen_uci(engine2_command) as engine2,
+    ):
+        for game_index in range(games):
+            opening_fen = openings[(game_index // 2) % len(openings)]
+            engine1_is_white = game_index % 2 == 0
+            if engine1_is_white:
+                result = play_game(engine1, engine2, opening_fen, limit, max_moves)
+            else:
+                result = play_game(engine2, engine1, opening_fen, limit, max_moves)
+
+            if result == "1/2-1/2":
+                draws += 1
+            elif (result == "1-0") == engine1_is_white:
+                wins += 1
+            else:
+                losses += 1
+    return wins, losses, draws
+
+
+def load_openings(path):
+    openings = []
+    with open(path) as handle:
+        for line in handle:
+            line = line.strip()
+            if line and not line.startswith("#"):
+                openings.append(line)
+    return openings
+
+
+def make_limit(movetime, depth):
+    if depth is not None:
+        return chess.engine.Limit(depth=depth)
+    if movetime is not None:
+        return chess.engine.Limit(time=movetime / 1000.0)
+    return chess.engine.Limit(depth=4)
+
+
+def main():
+    default_engine = f"{sys.executable} src/main.py"
+    parser = argparse.ArgumentParser(
+        description="Play a self-play match and report Elo."
+    )
+    parser.add_argument(
+        "--engine1", default=default_engine, help="candidate UCI command"
+    )
+    parser.add_argument(
+        "--engine2", default=default_engine, help="baseline UCI command"
+    )
+    parser.add_argument(
+        "--games", type=int, help="games to play (default: openings x2)"
+    )
+    parser.add_argument("--movetime", type=int, help="milliseconds per move")
+    parser.add_argument(
+        "--depth", type=int, help="fixed depth per move (deterministic)"
+    )
+    parser.add_argument(
+        "--max-moves",
+        type=int,
+        default=200,
+        help="adjudicate a draw after this many moves",
+    )
+    parser.add_argument(
+        "--openings",
+        default="bench/openings.epd",
+        help="opening positions (FEN per line)",
+    )
+    args = parser.parse_args()
+
+    openings = load_openings(args.openings)
+    games = args.games if args.games is not None else len(openings) * 2
+    limit = make_limit(args.movetime, args.depth)
+
+    wins, losses, draws = run_match(
+        shlex.split(args.engine1),
+        shlex.split(args.engine2),
+        openings,
+        games,
+        limit,
+        args.max_moves,
+    )
+    score = 100 * (wins + 0.5 * draws) / games if games else 0.0
+    elo, margin = elo_estimate(wins, losses, draws)
+    print(
+        f"engine1 vs engine2: +{wins} -{losses} ={draws}, "
+        f"{score:.1f}%, Elo {elo:+.0f} ± {margin:.0f}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -1,0 +1,49 @@
+"""Fast self-test for the strength harness: exercise both runners on tiny inputs
+so the gate guards the tools without running a full suite or match."""
+
+import sys
+from pathlib import Path
+
+import chess
+import chess.engine
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import epd_suite  # noqa: E402
+import selfplay  # noqa: E402
+
+MINI_EPD = [
+    '6k1/5ppp/8/8/8/8/5PPP/R5K1 w - - bm Ra8; id "mini.1";',
+    '3q3k/8/8/8/8/8/8/3Q3K w - - bm Qxd8; id "mini.2";',
+]
+
+
+def test_epd_runner_solves_easy_tactics():
+    solved, total, failures = epd_suite.run(MINI_EPD, depth=4)
+    assert total == 2
+    assert solved == 2, failures
+
+
+def test_elo_estimate_even_match_is_zero():
+    elo, _margin = selfplay.elo_estimate(10, 10, 0)
+    assert abs(elo) < 1e-6
+
+
+def test_elo_estimate_favors_the_winner():
+    elo, margin = selfplay.elo_estimate(75, 25, 0)
+    assert 180 < elo < 200
+    assert margin > 0
+
+
+def test_selfplay_reports_a_single_game_result():
+    engine = [sys.executable, str(REPO_ROOT / "src" / "main.py")]
+    wins, losses, draws = selfplay.run_match(
+        engine,
+        engine,
+        [chess.STARTING_FEN],
+        games=1,
+        limit=chess.engine.Limit(depth=1),
+        max_moves=20,
+    )
+    assert wins + losses + draws == 1


### PR DESCRIPTION
## Summary

This PR adds a strength-measurement harness: two on-demand tools in `scripts/`.
`epd_suite.py` reports a tactical solve-rate on an EPD suite; `selfplay.py` plays
two UCI engines and reports the result and an Elo estimate. `python-chess` is the
independent oracle. The spec is in `roadmap/specs/strength-harness/`.

## Motivation

Until now, "is this change stronger?" was a guess. With iterative deepening in
place, self-play is meaningful, so we can measure. The harness turns any engine
change into a number: a solve-rate delta on a fixed tactical suite, and an Elo
delta from a candidate-versus-baseline match. Every future search or eval change
can now report evidence instead of a hunch.

## What Changed

- `scripts/epd_suite.py` searches each EPD position at a fixed `movetime` or
  `depth` and reports the solve-rate and the failures. `python-chess` parses the
  EPD and converts the `bm` best-moves to UCI.
- `scripts/selfplay.py` plays two UCI engine commands over a set of openings and
  reports wins, losses, draws, the score rate, and an Elo estimate with an error
  margin. `python-chess` drives each engine as a subprocess and arbitrates the
  games. Build a baseline in a git worktree to compare against a candidate.
- `bench/wac.epd`, an attributed Win At Chess sample (the runner accepts any EPD
  file for fuller suites), and `bench/openings.epd` for self-play variety.
- No new dependencies: `python-chess` is already a test dep.
- Glossary, `AGENTS.md`, and the board updated.

## Tests

- 24 pytest and 30 cargo, plus ruff, clippy, and the knowledge check. The pre-push
  hook ran the gate.
- A fast self-test exercises both runners: the EPD runner solves a two-position
  mini-suite, the Elo formula is checked for known score rates, and a single
  shallow self-play game returns a result. Full suites and matches are manual,
  kept out of the fast gate.
- Measured on the way in: the engine solves 9 of 10 WAC sample positions at depth 6.

To run it: install a Rust toolchain (https://rustup.rs), then
`.venv/bin/maturin develop --release -m core/Cargo.toml` and `scripts/check-fast.sh`.
Try the tools with `.venv/bin/python scripts/epd_suite.py --depth 6 bench/wac.epd`.
