### PR TITLE
Killer-move and history ordering (measured flat: Elo +2 ± 21)

### DIFF
--- a/core/src/movesort.rs
+++ b/core/src/movesort.rs
@@ -1,9 +1,9 @@
-//! MoveSorter — orders legal moves to improve pruning, a port of
-//! `src/move_sorter.py`.
+//! MoveSorter — orders legal moves to improve pruning.
 //!
-//! Full search order: checks, then captures by MVV-LVA, then quiet moves by
-//! their position-value change. Quiescence uses checks + captures only (or every
-//! evasion when in check). `is_endgame` is the frozen root value.
+//! Full search order: the transposition-table move (placed first by the search),
+//! then checks, captures by MVV-LVA, and quiet moves. The quiet group leads with
+//! the ply's killer moves, then sorts by history score, with the piece-square
+//! change as the tiebreak. `is_endgame` is the frozen root value.
 
 use std::cmp::Reverse;
 
@@ -13,6 +13,32 @@ use crate::chess_move::Move;
 use crate::eval::{position_value, PIECE_VALUES};
 use crate::movegen::generate_legal;
 use crate::types::{Color, PieceType, Square};
+
+/// Flattened size of the history table: side × from × to.
+pub const HISTORY_SIZE: usize = 2 * 64 * 64;
+
+static EMPTY_HISTORY: [i32; HISTORY_SIZE] = [0; HISTORY_SIZE];
+
+/// Per-node ordering signals: the ply's killer moves and the history table.
+pub struct OrderingContext<'a> {
+    pub killers: [Option<Move>; 2],
+    pub history: &'a [i32],
+}
+
+impl OrderingContext<'static> {
+    /// No killers and zero history — for root fallbacks and tests.
+    pub fn empty() -> OrderingContext<'static> {
+        OrderingContext {
+            killers: [None, None],
+            history: &EMPTY_HISTORY,
+        }
+    }
+}
+
+/// The flattened history index for a move by the side to move.
+pub fn history_index(color: Color, mv: Move) -> usize {
+    color.index() * 4096 + (mv.from() as usize) * 64 + mv.to() as usize
+}
 
 pub fn in_check(board: &Board) -> bool {
     let us = board.side_to_move();
@@ -70,6 +96,30 @@ fn sort_by_value(board: &Board, mut moves: Vec<Move>, is_endgame: bool) -> Vec<M
     moves
 }
 
+/// Order quiet moves: killers first (slot 0 before slot 1), then by history score
+/// descending, with the piece-square change as the tiebreak.
+fn sort_quiets(
+    board: &Board,
+    mut quiets: Vec<Move>,
+    is_endgame: bool,
+    context: &OrderingContext,
+) -> Vec<Move> {
+    let color = board.side_to_move();
+    quiets.sort_by_key(|&mv| {
+        let killer_rank = if context.killers[0] == Some(mv) {
+            0
+        } else if context.killers[1] == Some(mv) {
+            1
+        } else {
+            2
+        };
+        let history = context.history[history_index(color, mv)];
+        let value = evaluate_move_value(board, mv, is_endgame);
+        (killer_rank, Reverse(history), Reverse(value))
+    });
+    quiets
+}
+
 /// Most Valuable Victim, Least Valuable Aggressor: highest victim first, then
 /// lowest aggressor.
 fn sort_mvv_lva(board: &Board, mut moves: Vec<Move>) -> Vec<Move> {
@@ -109,22 +159,30 @@ fn group(board: &mut Board, moves: &[Move]) -> (Vec<Move>, Vec<Move>, Vec<Move>)
     (checks, captures, quiets)
 }
 
-/// Legal moves ordered checks → captures (MVV-LVA) → quiet (by value).
-pub fn prioritize_legal_moves(board: &mut Board, is_endgame: bool) -> Vec<Move> {
+/// Legal moves ordered checks → captures (MVV-LVA) → quiet (killers, history, value).
+pub fn prioritize_legal_moves(
+    board: &mut Board,
+    is_endgame: bool,
+    context: &OrderingContext,
+) -> Vec<Move> {
     let moves = generate_legal(board);
     let (checks, captures, quiets) = group(board, &moves);
     let mut ordered = Vec::with_capacity(moves.len());
     ordered.extend(sort_by_value(board, checks, is_endgame));
     ordered.extend(sort_mvv_lva(board, captures));
-    ordered.extend(sort_by_value(board, quiets, is_endgame));
+    ordered.extend(sort_quiets(board, quiets, is_endgame, context));
     ordered
 }
 
 /// Moves searched in quiescence: every evasion when in check, else checks +
 /// captures.
-pub fn get_moves_to_dequiet(board: &mut Board, is_endgame: bool) -> Vec<Move> {
+pub fn get_moves_to_dequiet(
+    board: &mut Board,
+    is_endgame: bool,
+    context: &OrderingContext,
+) -> Vec<Move> {
     if in_check(board) {
-        return prioritize_legal_moves(board, is_endgame);
+        return prioritize_legal_moves(board, is_endgame, context);
     }
     let moves = generate_legal(board);
     let (checks, captures, _quiets) = group(board, &moves);
@@ -143,8 +201,7 @@ mod tests {
         let mut board =
             Board::from_fen("rnbqkbnr/pppp1ppp/8/4p2Q/4P3/8/PPPP1PPP/RNB1KBNR w KQkq - 0 1")
                 .unwrap();
-        let ordered = prioritize_legal_moves(&mut board, false);
-        // Rank each move by its group; the sequence must be non-decreasing.
+        let ordered = prioritize_legal_moves(&mut board, false, &OrderingContext::empty());
         let ranks: Vec<u8> = ordered
             .iter()
             .map(|&mv| {
@@ -167,7 +224,6 @@ mod tests {
 
     #[test]
     fn mvv_lva_prefers_capturing_the_higher_value_victim() {
-        // White can play e4xd5 (pawn takes queen) or Qa1xa7 (queen takes pawn).
         let mut board = Board::from_fen("6k1/p7/8/3q4/4P3/8/8/Q3K3 w - - 0 1").unwrap();
         let captures: Vec<Move> = generate_legal(&mut board)
             .into_iter()
@@ -175,5 +231,39 @@ mod tests {
             .collect();
         let ordered = sort_mvv_lva(&board, captures);
         assert_eq!(ordered[0].to_uci(), "e4d5");
+    }
+
+    fn quiet_moves(fen: &str) -> (Board, Vec<Move>) {
+        let mut board = Board::from_fen(fen).unwrap();
+        let legal = generate_legal(&mut board);
+        let (_, _, quiets) = group(&mut board, &legal);
+        (board, quiets)
+    }
+
+    #[test]
+    fn a_killer_quiet_sorts_ahead_of_its_peers() {
+        let (board, quiets) = quiet_moves("4k3/8/8/8/8/8/8/R3K3 w - - 0 1");
+        assert!(quiets.len() >= 6);
+        let killer = quiets[3];
+        let context = OrderingContext {
+            killers: [Some(killer), None],
+            history: &EMPTY_HISTORY,
+        };
+        let ordered = sort_quiets(&board, quiets, false, &context);
+        assert_eq!(ordered[0], killer);
+    }
+
+    #[test]
+    fn history_orders_otherwise_equal_quiets() {
+        let (board, quiets) = quiet_moves("4k3/8/8/8/8/8/8/R3K3 w - - 0 1");
+        let favored = quiets[3];
+        let mut history = vec![0i32; HISTORY_SIZE];
+        history[history_index(board.side_to_move(), favored)] = 1000;
+        let context = OrderingContext {
+            killers: [None, None],
+            history: &history,
+        };
+        let ordered = sort_quiets(&board, quiets, false, &context);
+        assert_eq!(ordered[0], favored);
     }
 }

--- a/core/src/search.rs
+++ b/core/src/search.rs
@@ -8,7 +8,10 @@ use crate::board::Board;
 use crate::chess_move::Move;
 use crate::eval;
 use crate::movegen::generate_legal;
-use crate::movesort::{get_moves_to_dequiet, in_check, prioritize_legal_moves};
+use crate::movesort::{
+    get_moves_to_dequiet, history_index, in_check, prioritize_legal_moves, OrderingContext,
+    HISTORY_SIZE,
+};
 use crate::tt::{Flag, HashEntry, TranspositionTable};
 use crate::types::Color;
 
@@ -28,6 +31,8 @@ const SUDDEN_DEATH_MOVES: u64 = 30;
 const MAX_BUDGET_PERCENT: u64 = 40;
 /// PV table / ply array bound.
 const MAX_SEARCH_PLY: usize = 128;
+/// Clamp history scores to keep them bounded and ordering stable.
+const HISTORY_MAX: i32 = 1 << 24;
 
 /// The limits for one search. All times are milliseconds.
 #[derive(Clone, Copy, Default)]
@@ -63,7 +68,11 @@ pub struct Searcher<'a> {
     transposition_table: &'a mut TranspositionTable,
     is_endgame: bool,
     /// Zobrist keys along the current line, for threefold-repetition detection.
-    history: Vec<u64>,
+    position_history: Vec<u64>,
+    /// History-heuristic scores, indexed `[side][from][to]` flattened.
+    history: Vec<i32>,
+    /// Two killer moves per ply.
+    killers: Vec<[Option<Move>; 2]>,
     nodes: u64,
     deadline: Option<Instant>,
     stopped: bool,
@@ -76,7 +85,9 @@ impl<'a> Searcher<'a> {
         Searcher {
             transposition_table,
             is_endgame,
-            history: Vec::new(),
+            position_history: Vec::new(),
+            history: vec![0; HISTORY_SIZE],
+            killers: vec![[None, None]; MAX_SEARCH_PLY],
             nodes: 0,
             deadline: None,
             stopped: false,
@@ -98,7 +109,7 @@ impl<'a> Searcher<'a> {
 
         // Fallback so we always return a legal move, even if depth 1 is cut off.
         let mut result = SearchResult {
-            best_move: prioritize_legal_moves(board, self.is_endgame)
+            best_move: prioritize_legal_moves(board, self.is_endgame, &OrderingContext::empty())
                 .into_iter()
                 .next(),
             score: 0,
@@ -133,11 +144,12 @@ impl<'a> Searcher<'a> {
     /// path and the tactical tests.
     pub fn best_move(&mut self, board: &mut Board, depth: i32) -> Option<Move> {
         let (best, _score) = self.negamax(board, depth, -MATE, MATE, 0);
-        best.or_else(|| {
-            prioritize_legal_moves(board, self.is_endgame)
-                .into_iter()
-                .next()
-        })
+        if best.is_some() {
+            return best;
+        }
+        prioritize_legal_moves(board, self.is_endgame, &OrderingContext::empty())
+            .into_iter()
+            .next()
     }
 
     /// Capture a decision tree `tree_depth` plies deep — the debug diagnostic.
@@ -151,7 +163,7 @@ impl<'a> Searcher<'a> {
         if tree_depth == 0 {
             return Vec::new();
         }
-        let moves = prioritize_legal_moves(board, self.is_endgame);
+        let moves = prioritize_legal_moves(board, self.is_endgame, &self.ordering_context(ply));
         let mut nodes = Vec::with_capacity(moves.len());
         for mv in moves {
             let undo = board.make_move(mv);
@@ -190,9 +202,9 @@ impl<'a> Searcher<'a> {
         ply: i32,
     ) -> (Option<Move>, i32) {
         let zobrist_key = board.zobrist();
-        self.history.push(zobrist_key);
+        self.position_history.push(zobrist_key);
         let result = self.search_node(board, depth, alpha, beta, ply, zobrist_key);
-        self.history.pop();
+        self.position_history.pop();
         result
     }
 
@@ -257,13 +269,17 @@ impl<'a> Searcher<'a> {
             if depth < QUIESCENCE_FLOOR {
                 return (None, stand_pat);
             }
-            let captures_and_checks = get_moves_to_dequiet(board, self.is_endgame);
+            let captures_and_checks =
+                get_moves_to_dequiet(board, self.is_endgame, &self.ordering_context(ply));
             if captures_and_checks.is_empty() {
                 return (None, stand_pat);
             }
             order_tt_move_first(captures_and_checks, tt_move)
         } else {
-            order_tt_move_first(prioritize_legal_moves(board, self.is_endgame), tt_move)
+            order_tt_move_first(
+                prioritize_legal_moves(board, self.is_endgame, &self.ordering_context(ply)),
+                tt_move,
+            )
         };
 
         let mut best_score = -MATE;
@@ -289,6 +305,9 @@ impl<'a> Searcher<'a> {
             }
             alpha = alpha.max(best_score);
             if alpha >= beta {
+                if depth > 0 {
+                    self.record_cutoff(board, mv, depth, ply);
+                }
                 break;
             }
         }
@@ -328,11 +347,39 @@ impl<'a> Searcher<'a> {
         if board.halfmove_clock() >= 100 {
             return true;
         }
-        self.history
+        self.position_history
             .iter()
             .filter(|&&seen| seen == zobrist_key)
             .count()
             >= 3
+    }
+
+    fn ordering_context(&self, ply: i32) -> OrderingContext<'_> {
+        let killers = self
+            .killers
+            .get(ply as usize)
+            .copied()
+            .unwrap_or([None, None]);
+        OrderingContext {
+            killers,
+            history: &self.history,
+        }
+    }
+
+    /// Credit a quiet move that caused a beta-cutoff: store it as a killer for the
+    /// ply and bump its history score.
+    fn record_cutoff(&mut self, board: &Board, mv: Move, depth: i32, ply: i32) {
+        if mv.is_capture() || mv.promotion().is_some() {
+            return;
+        }
+        if let Some(slot) = self.killers.get_mut(ply as usize) {
+            if slot[0] != Some(mv) {
+                slot[1] = slot[0];
+                slot[0] = Some(mv);
+            }
+        }
+        let index = history_index(board.side_to_move(), mv);
+        self.history[index] = (self.history[index] + depth * depth).min(HISTORY_MAX);
     }
 }
 
@@ -652,5 +699,57 @@ mod tests {
         let cold = nodes(MIDGAME, 5, false);
         let warm = nodes(MIDGAME, 5, true);
         assert!(warm < cold, "warm {warm} should be < cold {cold}");
+    }
+
+    // --- Epic 3: killers and history ---
+
+    #[test]
+    fn killers_and_history_update_on_a_quiet_cutoff() {
+        let mut board = Board::from_fen("4k3/8/8/8/8/8/8/R3K3 w - - 0 1").unwrap();
+        let mut table = TranspositionTable::new();
+        let mut searcher = Searcher::new(&mut table, false);
+
+        // AC-3.1: a new Searcher starts empty.
+        assert!(searcher.killers.iter().all(|slot| *slot == [None, None]));
+        assert!(searcher.history.iter().all(|&score| score == 0));
+
+        let quiets: Vec<Move> = generate_legal(&mut board)
+            .into_iter()
+            .filter(|mv| !mv.is_capture() && mv.promotion().is_none())
+            .collect();
+        let (first, second) = (quiets[0], quiets[1]);
+
+        // AC-1.1, AC-2.1: a quiet cutoff stores a killer and adds depth².
+        searcher.record_cutoff(&board, first, 4, 0);
+        assert_eq!(searcher.killers[0][0], Some(first));
+        assert_eq!(
+            searcher.history[history_index(board.side_to_move(), first)],
+            16
+        );
+
+        // AC-1.4: a distinct killer shifts into the first slot.
+        searcher.record_cutoff(&board, second, 3, 0);
+        assert_eq!(searcher.killers[0], [Some(second), Some(first)]);
+
+        // AC-1.3: recording the same killer leaves the slots unchanged.
+        searcher.record_cutoff(&board, second, 2, 0);
+        assert_eq!(searcher.killers[0], [Some(second), Some(first)]);
+    }
+
+    #[test]
+    fn history_accumulates_across_iterations() {
+        // AC-3.2: the table fills as iterative deepening runs.
+        let mut board = Board::from_fen(MIDGAME).unwrap();
+        let mut table = TranspositionTable::new();
+        let mut searcher = Searcher::new(&mut table, false);
+        searcher.search(
+            &mut board,
+            &SearchLimits {
+                max_depth: 5,
+                ..Default::default()
+            },
+            Instant::now(),
+        );
+        assert!(searcher.history.iter().any(|&score| score > 0));
     }
 }

--- a/knowledge/glossary.md
+++ b/knowledge/glossary.md
@@ -48,6 +48,8 @@ field, and record must fit. The chess logic lives in the Rust core
 | Zobrist hash | The key identifying a position in the transposition table | `Board::zobrist` | `chess.polyglot.zobrist_hash` |
 | HashEntry | One transposition-table record: move, depth, value, bound flag, age | `HashEntry`, `Flag` | |
 | MVV-LVA | Most Valuable Victim – Least Valuable Aggressor — capture-ordering heuristic | `movesort` | |
+| Killer move | A quiet move that caused a beta-cutoff at a ply, tried first there next time | `killers` | |
+| History heuristic | A from-to score table of cutoff frequency that orders quiet moves | `history` | |
 | Negamax | Minimax reformulated so each node negates the child's score | `negamax` | |
 | Bitboard | A 64-bit word, one bit per square, encoding a piece set | `Bitboard` | |
 | Magic bitboard | Perfect-hash lookup of a slider's attacks by blocker configuration | | |
@@ -69,8 +71,8 @@ field, and record must fit. The chess logic lives in the Rust core
 | Elo | A rating-difference estimate from a match's score rate | `selfplay.py` | |
 
 Bitboard, magic bitboard, make/unmake, piece-square table, negamax, iterative
-deepening, the triangular PV-table, mate scores, and the centipawn follow
-[Chess Programming Wiki](https://www.chessprogramming.org/) conventions; perft,
-MVV-LVA, EPD, Elo, and self-play already did. The time-control tokens are UCI;
+deepening, the triangular PV-table, mate scores, the centipawn, and the killer and
+history heuristics follow [Chess Programming Wiki](https://www.chessprogramming.org/)
+conventions; perft, MVV-LVA, EPD, Elo, and self-play already did. The time-control tokens are UCI;
 `SearchLimits` follows Stockfish's `LimitsType`. `brandobot_core` is this repo's
 PyO3 module name.

--- a/roadmap/ROADMAP.md
+++ b/roadmap/ROADMAP.md
@@ -89,3 +89,15 @@ change instead of guessing.
 | EPD tactical suite (solve-rate) (@branransom) | Done | [strength-harness](specs/strength-harness/design.md) | Iterative deepening |
 | Self-play match (Elo) (@branransom) | Done | [strength-harness](specs/strength-harness/design.md) | Iterative deepening |
 | Gate self-test + docs (@branransom) | Done | [strength-harness](specs/strength-harness/design.md) | EPD tactical suite (solve-rate), Self-play match (Elo) |
+
+### Epic 3 — Killer-move and history ordering
+
+Order quiet moves with killer moves and the history heuristic so alpha-beta cuts
+more and the search reaches greater depth in the same time. Ordering stays one
+composed function; the gain is measured with the strength harness.
+
+| Work | Status | Spec | Depends on |
+|---|---|---|---|
+| Killer moves | Planned | [killers-history](specs/killers-history/design.md) | Iterative deepening |
+| History heuristic | Planned | [killers-history](specs/killers-history/design.md) | Killer moves |
+| Measure (Elo) + docs | Planned | [killers-history](specs/killers-history/design.md) | History heuristic, Strength measurement |

--- a/roadmap/ROADMAP.md
+++ b/roadmap/ROADMAP.md
@@ -98,6 +98,6 @@ composed function; the gain is measured with the strength harness.
 
 | Work | Status | Spec | Depends on |
 |---|---|---|---|
-| Killer moves | Planned | [killers-history](specs/killers-history/design.md) | Iterative deepening |
-| History heuristic | Planned | [killers-history](specs/killers-history/design.md) | Killer moves |
-| Measure (Elo) + docs | Planned | [killers-history](specs/killers-history/design.md) | History heuristic, Strength measurement |
+| Killer moves (@branransom) | Done | [killers-history](specs/killers-history/design.md) | Iterative deepening |
+| History heuristic (@branransom) | Done | [killers-history](specs/killers-history/design.md) | Killer moves |
+| Measure (Elo) + docs (@branransom) | Done | [killers-history](specs/killers-history/design.md) | History heuristic, Strength measurement |

--- a/roadmap/specs/killers-history/design.md
+++ b/roadmap/specs/killers-history/design.md
@@ -1,0 +1,97 @@
+---
+title: Killers and history — design
+description: Killer-move and history-heuristic ordering of quiet moves, as one composed function, measured with the harness.
+---
+
+> **Status:** Planned (2026-06-15) — tracked on the [board](../../ROADMAP.md).
+
+# Killers and history — design
+
+## Decision summary
+
+| Decision | Choice | Why |
+|---|---|---|
+| Scope | Quiet-move ordering only | Captures, checks, and the TT move already order well. |
+| Structure | One composed function | No strategy pattern in the hot path; add terms, not strategies. |
+| Killers | 2 per ply | The standard; cheap and effective. |
+| History bonus | `depth²` on a quiet cutoff | The conventional weighting; deeper cutoffs count more. |
+| Lifetime | Per search, across iterations | Fresh each move; accumulates within iterative deepening. |
+| Verification | Tactics + units + harness Elo | Correctness by tests; strength by measurement, not assumption. |
+
+## Killer moves
+
+A table `killers: [[Option<Move>; 2]; MAX_PLY]` on the `Searcher`. At a beta-cutoff
+where the cutting move is **quiet** (not a capture or promotion), shift it into the
+ply's slots: `killers[ply][1] = killers[ply][0]; killers[ply][0] = mv`, unless it
+already equals `killers[ply][0]` (dedupe). In ordering, a ply's killers lead the
+quiet group, first slot before second.
+
+## History heuristic
+
+A table `history: [[[i32; 64]; 64]; 2]` indexed by side to move, from square, and
+to square. At a quiet-move beta-cutoff, add `depth²` to `history[side][from][to]`.
+Scores are clamped to avoid overflow over a long search. The non-killer quiet moves
+sort by history score descending, with the piece-square-table change as the
+tiebreak (the current quiet order).
+
+## Ordering integration
+
+`move_sorter` stays the composed function. It gains an `OrderingContext` carrying
+the ply's killers (`[Option<Move>; 2]`) and a borrow of the history table; the
+`Searcher` builds it per node from `killers[ply]` and `&self.history` and passes it
+to `prioritize_legal_moves` / `get_moves_to_dequiet`. The quiet group becomes:
+
+```
+killers (slot 0, then slot 1) → remaining quiets by history desc → PST-delta tiebreak
+```
+
+Checks and captures keep their place; the TT move still leads the whole list
+(Epic 1). The updates fire at the existing `alpha >= beta` cutoff in `search_node`,
+guarded to quiet moves.
+
+The escape hatch if a second ordering must coexist: a generic
+`Searcher<O: MoveOrderer>` (monomorphized, no `dyn`). Not built.
+
+## Lifetime
+
+The tables live on the `Searcher`, which is created fresh per move, so they start
+empty each move and accumulate across the iterative-deepening iterations within one
+search. No cross-move aging is needed.
+
+## Verification
+
+- **Correctness:** the four tactical tests still pass — ordering changes speed, not
+  results. Move generation and perft are untouched.
+- **Units:** the killer shift/dedupe keeps two distinct moves and leads the quiet
+  group; a history bump reorders two otherwise-equal quiets.
+- **Strength:** build the candidate against the pre-epic `main` baseline in a
+  worktree and run `selfplay.py`; record the Elo delta in the PR. This is evidence,
+  not a blocking gate — small deltas need hundreds of games.
+
+## Naming and provenance
+
+| Term | Definition | Provenance |
+|---|---|---|
+| Killer move | A quiet move that caused a beta-cutoff at a ply, tried first there next time | CPW "Killer Heuristic" |
+| History heuristic | A from-to score table of cutoff frequency that orders quiet moves | CPW "History Heuristic" |
+
+Internal names stay expressive (`killers`, `history`, `OrderingContext`). Both
+terms enter `knowledge/glossary.md` in Wave 3.2; they are not in the glossary yet.
+
+## Alternatives considered
+
+- **Strategy pattern for ordering.** Rejected: a virtual call per decision taxes
+  the hot path, and the variation is composition, not whole-strategy swap; the
+  harness is the A/B mechanism.
+- **Captures-first regrouping** (drop the checks-first quirk). Out of scope: a
+  separable change, measurable on its own later.
+- **History penalties for failed quiets / butterfly boards.** Deferred: start with
+  the cutoff bonus and measure before adding complexity.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| A killer or history move is illegal in the current position | Promote only moves present in the generated quiet list; a miss is a no-op. |
+| History overflow over a long search | Clamp scores to a bound. |
+| The change helps tactics but not games | Measure with self-play before claiming a gain; the harness exists for this. |

--- a/roadmap/specs/killers-history/design.md
+++ b/roadmap/specs/killers-history/design.md
@@ -3,7 +3,7 @@ title: Killers and history — design
 description: Killer-move and history-heuristic ordering of quiet moves, as one composed function, measured with the harness.
 ---
 
-> **Status:** Planned (2026-06-15) — tracked on the [board](../../ROADMAP.md).
+> **Status:** Done (2026-06-15) — tracked on the [board](../../ROADMAP.md).
 
 # Killers and history — design
 
@@ -68,6 +68,11 @@ search. No cross-move aging is needed.
   worktree and run `selfplay.py`; record the Elo delta in the PR. This is evidence,
   not a blocking gate — small deltas need hundreds of games.
 
+**Measured result:** Elo +2 ± 21 over 300 games at 100 ms/move — no measurable
+strength gain — and ~6% more nodes at fixed depth. The PST-based quiet order was
+already strong, so history-primary ordering did not improve it. Kept as standard
+infrastructure for later ordering and evaluation work, which may make it pay off.
+
 ## Naming and provenance
 
 | Term | Definition | Provenance |
@@ -76,7 +81,7 @@ search. No cross-move aging is needed.
 | History heuristic | A from-to score table of cutoff frequency that orders quiet moves | CPW "History Heuristic" |
 
 Internal names stay expressive (`killers`, `history`, `OrderingContext`). Both
-terms enter `knowledge/glossary.md` in Wave 3.2; they are not in the glossary yet.
+terms are recorded in `knowledge/glossary.md`.
 
 ## Alternatives considered
 

--- a/roadmap/specs/killers-history/requirements.md
+++ b/roadmap/specs/killers-history/requirements.md
@@ -1,0 +1,55 @@
+---
+title: Killers and history — requirements
+description: User stories and EARS acceptance criteria for killer-move and history-heuristic ordering of quiet moves.
+---
+
+> **Status:** Planned (2026-06-15) — tracked on the [board](../../ROADMAP.md).
+
+# Killers and history — requirements
+
+Order quiet moves with two learned signals so alpha-beta cuts more and the search
+reaches greater depth in the same time. Captures (MVV-LVA), checks, and the
+transposition-table move (Epic 1) keep their place; only the quiet group changes.
+Move ordering stays one composed function. The gain is measured with the
+strength harness, not assumed.
+
+## Story 1 — Killer moves
+
+As the engine, I want the quiet moves that recently cut off at a ply tried first,
+so similar positions prune sooner.
+
+- AC-1.1 WHEN a quiet move causes a beta-cutoff at a ply, THE SYSTEM SHALL record it as a killer move for that ply.
+- AC-1.2 WHEN the quiet group is ordered, THE SYSTEM SHALL place that ply's killer moves at its front.
+- AC-1.3 WHEN a recorded killer equals the ply's first killer, THE SYSTEM SHALL leave the ply's killer slots unchanged.
+- AC-1.4 WHEN a recorded killer differs from the ply's first killer, THE SYSTEM SHALL shift it into the first slot and keep the previous first as the second.
+
+## Story 2 — History heuristic
+
+As the engine, I want quiet moves that cut off often anywhere tried earlier, so
+ordering improves as the search runs.
+
+- AC-2.1 WHEN a quiet move causes a beta-cutoff, THE SYSTEM SHALL add `depth²` (the square of the remaining search depth) to that move's history score, indexed by side to move, from square, and to square.
+- AC-2.2 WHEN the non-killer quiet moves are ordered, THE SYSTEM SHALL sort them by history score, highest first.
+- AC-2.3 WHEN two quiet moves have equal history score, THE SYSTEM SHALL break the tie by the piece-square-table change.
+
+## Story 3 — Lifetime
+
+As the engine, I want the tables scoped to one search, so they help across
+iterations without leaking between moves.
+
+- AC-3.1 WHEN a new `Searcher` is created, THE SYSTEM SHALL start with empty killer and history tables.
+- AC-3.2 WHEN iterative deepening runs within one search, THE SYSTEM SHALL retain the killer and history tables across depths.
+
+## Story 4 — Correctness preserved
+
+As the maintainer, I want the same moves found, so ordering changes speed and not
+results.
+
+- AC-4.1 WHEN searched to depth 3, THE SYSTEM SHALL still return `f8f7`, `h7h8`, `f6a6`, and not `e1e8` for the four tactical positions.
+
+## Story 5 — Measured strength
+
+As the maintainer, I want evidence the change helps, so strength claims are
+verified.
+
+- AC-5.1 WHEN the candidate plays the pre-epic baseline through `selfplay.py`, THE SYSTEM SHALL record the Elo delta in the pull request.

--- a/roadmap/specs/killers-history/requirements.md
+++ b/roadmap/specs/killers-history/requirements.md
@@ -3,7 +3,7 @@ title: Killers and history — requirements
 description: User stories and EARS acceptance criteria for killer-move and history-heuristic ordering of quiet moves.
 ---
 
-> **Status:** Planned (2026-06-15) — tracked on the [board](../../ROADMAP.md).
+> **Status:** Done (2026-06-15) — tracked on the [board](../../ROADMAP.md).
 
 # Killers and history — requirements
 

--- a/roadmap/specs/killers-history/tasks.md
+++ b/roadmap/specs/killers-history/tasks.md
@@ -1,0 +1,41 @@
+---
+title: Killers and history — tasks
+description: Waved plan for killer-move and history-heuristic quiet ordering; each task names its gate.
+---
+
+> **Status:** Planned (2026-06-15) — tracked on the [board](../../ROADMAP.md).
+
+# Killers and history — tasks
+
+Tasks within a wave are independent; each wave builds on the last. Every task
+names its gate. Apply the changes in `search.rs` and `movesort.rs`; the existing
+cargo gate (fmt, clippy, test) and the tactical tests cover correctness.
+
+## Wave 1 — Killer moves
+
+- **1.1 Killer table + update.** Add `killers` to the `Searcher`; at the quiet-move
+  beta-cutoff in `search_node`, shift the move into the ply's slots with dedupe.
+  *Gate: AC-1.1, AC-1.3, AC-1.4 — a unit test on the shift and dedupe.*
+- **1.2 Ordering context + killers first.** Thread an `OrderingContext` (the ply's
+  killers, the history borrow) into `prioritize_legal_moves` /
+  `get_moves_to_dequiet`; place killers at the front of the quiet group. *Gate:
+  AC-1.2, AC-4.1 — killers lead the quiet group and the four tactical tests pass.*
+
+## Wave 2 — History heuristic
+
+- **2.1 History table + update.** Add `history` to the `Searcher`; at the quiet-move
+  cutoff, add `depth²`, clamped. *Gate: AC-2.1, AC-3.1–3.2 — a unit test that the
+  bump adds `depth²` at `[side][from][to]`, the tables are empty on a new Searcher,
+  and retained across iterations.*
+- **2.2 History ordering.** Sort the non-killer quiets by history score, PST-delta
+  as the tiebreak. *Gate: AC-2.2–2.3, AC-4.1 — a unit test reorders two equal quiets
+  by history, and the tactical tests still pass.*
+
+## Wave 3 — Measure & docs
+
+- **3.1 Strength measurement.** Build the candidate against the pre-epic `main`
+  baseline and run `selfplay.py`; record the Elo delta. *Gate: AC-5.1 — the Elo
+  delta is recorded in the PR.*
+- **3.2 Docs & board.** Add Killer move and History heuristic to
+  `knowledge/glossary.md` with provenance; move the Epic 3 cards to Done. *Gate:
+  `python3 scripts/knowledge.py check` clean; recorded gate PASS.*

--- a/roadmap/specs/killers-history/tasks.md
+++ b/roadmap/specs/killers-history/tasks.md
@@ -3,7 +3,7 @@ title: Killers and history — tasks
 description: Waved plan for killer-move and history-heuristic quiet ordering; each task names its gate.
 ---
 
-> **Status:** Planned (2026-06-15) — tracked on the [board](../../ROADMAP.md).
+> **Status:** Done (2026-06-15) — tracked on the [board](../../ROADMAP.md).
 
 # Killers and history — tasks
 


### PR DESCRIPTION
## Summary

Adds killer-move and history-heuristic ordering of quiet moves to the Rust search,
as one composed function. Measured against the pre-epic baseline, it shows **no
strength gain** (Elo +2 ± 21 over 300 games), so it merges as standard
infrastructure, not a win. The spec is in `roadmap/specs/killers-history/`.

## Motivation

Killers and history are the textbook way to order quiet moves, where alpha-beta is
weakest. We added them and then measured the result with the self-play harness
rather than assuming a gain. The measurement is the point. It showed the change is
flat for this engine: the eval is piece-square-table based, so the existing
PST-delta quiet order already tracks move quality, and making history the primary
key displaces it with a noisier signal. The implementation is clean and standard,
so we keep it as a foundation for later ordering and evaluation work that may make
it pay off, with the negative result recorded.

## What Changed

- Quiet moves order killers (slot 0, then slot 1), then history descending, with
  the PST-delta as the tiebreak, as one composed ordering function (no strategy
  pattern). An `OrderingContext` threads the ply's killers and the history table
  into the move sorter.
- Killer and history tables live on the `Searcher`, fresh per move, accumulating
  across iterative-deepening iterations; updates fire at the quiet-move beta-cutoff
  (a `depth²` history bonus, clamped).
- Renames the repetition history to `position_history` to free the name.
- The glossary gains Killer move and History heuristic with CPW provenance.

## Tests

- 34 cargo and 24 pytest, plus ruff, clippy, and the knowledge check. The pre-push
  hook ran the gate.
- New units: the killer shift and dedupe, the history bump and lifetime, and the
  quiet reordering by killers and by history. The four tactical tests are unchanged
  (ordering changes speed, not results).
- Strength measured with the harness: candidate vs the pre-epic `main` baseline,
  300 games at 100 ms/move gives Elo +2 ± 21 (no measurable gain), and ~6% more
  nodes at fixed depth. The result is recorded in the spec.
