### PR TITLE
feat(parallel-search): Lazy SMP — Waves 1–4 + search-diversity spec

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -24,7 +24,7 @@ use pyo3::types::{PyDict, PyList};
 use board::Board;
 use chess_move::parse_uci;
 use movegen::generate_legal;
-use tt::{Flag, TranspositionTable};
+use tt::{Flag, VecTt};
 
 /// The UCI null move, returned when no legal move exists.
 const NULL_MOVE: &str = "0000";
@@ -54,12 +54,14 @@ impl CapturedNode {
     }
 }
 
-/// Searcher — owns a Board and a TranspositionTable and returns the best Move for
-/// the current position. The Python wrappers hold one per game.
-#[pyclass]
+/// Searcher — owns a Board and a transposition table and returns the best Move
+/// for the current position. The Python wrappers hold one per game. `unsendable`
+/// because the `VecTt` backend is `RefCell`-backed (`!Sync`): the engine object
+/// is thread-affine to the Python thread that drives it.
+#[pyclass(unsendable)]
 struct Searcher {
     board: Board,
-    transposition_table: TranspositionTable,
+    transposition_table: VecTt,
     last_decision_tree: Option<DecisionTree>,
     /// The NNUE network, when one has been loaded; otherwise leaf positions use
     /// the hand-written evaluation. Engine configuration, not game state — it
@@ -73,7 +75,7 @@ impl Searcher {
     fn new() -> Self {
         Searcher {
             board: Board::startpos(),
-            transposition_table: TranspositionTable::new(),
+            transposition_table: VecTt::new(),
             last_decision_tree: None,
             eval_net: None,
         }
@@ -83,7 +85,7 @@ impl Searcher {
     /// any captured decision tree. The loaded NNUE network, if any, is kept.
     fn new_game(&mut self) {
         self.board = Board::startpos();
-        self.transposition_table = TranspositionTable::new();
+        self.transposition_table = VecTt::new();
         self.last_decision_tree = None;
     }
 
@@ -162,15 +164,15 @@ impl Searcher {
         if capture_tree {
             let plies = tree_depth.clamp(1, depth.max(1));
             let nodes = {
-                let mut scout = search::Searcher::new(&mut self.transposition_table)
+                let mut scout = search::Searcher::new(&self.transposition_table)
                     .with_eval_net(self.eval_net.as_ref());
                 scout.capture_tree(&mut self.board, depth as i32, plies, 0)
             };
             let captured = nodes.into_iter().map(CapturedNode::from_tree).collect();
             self.last_decision_tree = Some((self.board.to_fen(), captured));
         }
-        let mut searcher = search::Searcher::new(&mut self.transposition_table)
-            .with_eval_net(self.eval_net.as_ref());
+        let mut searcher =
+            search::Searcher::new(&self.transposition_table).with_eval_net(self.eval_net.as_ref());
         match searcher.best_move(&mut self.board, depth as i32) {
             Some(mv) => mv.to_uci(),
             None => NULL_MOVE.to_string(),
@@ -207,7 +209,7 @@ impl Searcher {
             node_limit,
         };
         let result = {
-            let mut searcher = search::Searcher::new(&mut self.transposition_table)
+            let mut searcher = search::Searcher::new(&self.transposition_table)
                 .with_eval_net(self.eval_net.as_ref());
             searcher.search(&mut self.board, &limits, std::time::Instant::now())
         };

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -24,7 +24,7 @@ use pyo3::types::{PyDict, PyList};
 use board::Board;
 use chess_move::parse_uci;
 use movegen::generate_legal;
-use tt::{ExclusiveTranspositionTable, Flag};
+use tt::{ExclusiveTranspositionTable, Flag, LocklessTranspositionTable};
 
 /// The UCI null move, returned when no legal move exists.
 const NULL_MOVE: &str = "0000";
@@ -67,6 +67,13 @@ struct Searcher {
     /// the hand-written evaluation. Engine configuration, not game state — it
     /// survives `new_game`.
     eval_net: Option<nnue::Network>,
+    /// Worker-thread count for time-based search (Lazy SMP). `1` keeps the
+    /// single-threaded path; `>1` runs that many workers over `lockless_table`.
+    /// Engine configuration, not game state — it survives `new_game`.
+    threads: usize,
+    /// The `Sync` table the parallel workers share; the single-threaded path uses
+    /// `transposition_table`. Cleared on `new_game`.
+    lockless_table: LocklessTranspositionTable,
 }
 
 #[pymethods]
@@ -78,15 +85,25 @@ impl Searcher {
             transposition_table: ExclusiveTranspositionTable::new(),
             last_decision_tree: None,
             eval_net: None,
+            threads: 1,
+            lockless_table: LocklessTranspositionTable::new(),
         }
     }
 
-    /// Reset to the starting position, clear the transposition table, and drop
-    /// any captured decision tree. The loaded NNUE network, if any, is kept.
+    /// Reset to the starting position, clear the transposition tables, and drop
+    /// any captured decision tree. The loaded NNUE network and thread count are kept.
     fn new_game(&mut self) {
         self.board = Board::startpos();
         self.transposition_table = ExclusiveTranspositionTable::new();
+        self.lockless_table = LocklessTranspositionTable::new();
         self.last_decision_tree = None;
+    }
+
+    /// Set the worker-thread count for time-based search (Lazy SMP). `1` keeps the
+    /// bit-identical single-threaded path; `>1` runs that many workers sharing the
+    /// lockless table. Node-limited search always runs single-threaded.
+    fn set_threads(&mut self, threads: usize) {
+        self.threads = threads.max(1);
     }
 
     /// Load an NNUE network from a file; leaf positions then evaluate through it
@@ -208,10 +225,22 @@ impl Searcher {
             moves_to_go,
             node_limit,
         };
-        let result = {
+        let now = std::time::Instant::now();
+        let result = if self.threads > 1 && limits.node_limit.is_none() {
+            // Lazy SMP: time-based parallel search over the shared lockless table.
+            // Node-limited search stays single-threaded for deterministic effort.
+            search::search_parallel(
+                &self.board,
+                &limits,
+                now,
+                &self.lockless_table,
+                self.threads,
+                self.eval_net.as_ref(),
+            )
+        } else {
             let mut searcher = search::Searcher::new(&self.transposition_table)
                 .with_eval_net(self.eval_net.as_ref());
-            searcher.search(&mut self.board, &limits, std::time::Instant::now())
+            searcher.search(&mut self.board, &limits, now)
         };
 
         let (score_centipawns, mate_in_moves) = match search::mate_in_moves(result.score) {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -24,7 +24,7 @@ use pyo3::types::{PyDict, PyList};
 use board::Board;
 use chess_move::parse_uci;
 use movegen::generate_legal;
-use tt::{Flag, VecTt};
+use tt::{ExclusiveTranspositionTable, Flag};
 
 /// The UCI null move, returned when no legal move exists.
 const NULL_MOVE: &str = "0000";
@@ -55,13 +55,13 @@ impl CapturedNode {
 }
 
 /// Searcher — owns a Board and a transposition table and returns the best Move
-/// for the current position. The Python wrappers hold one per game. `unsendable`
-/// because the `VecTt` backend is `RefCell`-backed (`!Sync`): the engine object
-/// is thread-affine to the Python thread that drives it.
+/// for the current position. The Python wrappers hold one per game. It is
+/// `unsendable` because the `ExclusiveTranspositionTable` backend is `RefCell`-backed
+/// (`!Sync`): the engine object is thread-affine to the Python thread that drives it.
 #[pyclass(unsendable)]
 struct Searcher {
     board: Board,
-    transposition_table: VecTt,
+    transposition_table: ExclusiveTranspositionTable,
     last_decision_tree: Option<DecisionTree>,
     /// The NNUE network, when one has been loaded; otherwise leaf positions use
     /// the hand-written evaluation. Engine configuration, not game state — it
@@ -75,7 +75,7 @@ impl Searcher {
     fn new() -> Self {
         Searcher {
             board: Board::startpos(),
-            transposition_table: VecTt::new(),
+            transposition_table: ExclusiveTranspositionTable::new(),
             last_decision_tree: None,
             eval_net: None,
         }
@@ -85,7 +85,7 @@ impl Searcher {
     /// any captured decision tree. The loaded NNUE network, if any, is kept.
     fn new_game(&mut self) {
         self.board = Board::startpos();
-        self.transposition_table = VecTt::new();
+        self.transposition_table = ExclusiveTranspositionTable::new();
         self.last_decision_tree = None;
     }
 

--- a/core/src/search.rs
+++ b/core/src/search.rs
@@ -68,8 +68,8 @@ pub struct TreeNode {
     pub children: Vec<TreeNode>,
 }
 
-pub struct Searcher<'a> {
-    transposition_table: &'a mut TranspositionTable,
+pub struct Searcher<'a, Tt: TranspositionTable> {
+    transposition_table: &'a Tt,
     /// Zobrist keys along the current line, for threefold-repetition detection.
     position_history: Vec<u64>,
     /// History-heuristic scores, indexed `[side][from][to]` flattened.
@@ -91,8 +91,8 @@ pub struct Searcher<'a> {
     accumulator: Option<Accumulator>,
 }
 
-impl<'a> Searcher<'a> {
-    pub fn new(transposition_table: &'a mut TranspositionTable) -> Searcher<'a> {
+impl<'a, Tt: TranspositionTable> Searcher<'a, Tt> {
+    pub fn new(transposition_table: &'a Tt) -> Searcher<'a, Tt> {
         crate::attacks::warm();
         Searcher {
             transposition_table,
@@ -111,7 +111,7 @@ impl<'a> Searcher<'a> {
 
     /// Evaluate leaf positions with `net` instead of the hand-written
     /// evaluation. `None` keeps the hand-written evaluation. Chains onto `new`.
-    pub fn with_eval_net(mut self, net: Option<&'a Network>) -> Searcher<'a> {
+    pub fn with_eval_net(mut self, net: Option<&'a Network>) -> Searcher<'a, Tt> {
         self.eval_net = net;
         self
     }
@@ -529,16 +529,17 @@ fn compute_budget_ms(side: Color, limits: &SearchLimits) -> Option<u64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tt::VecTt;
 
-    fn searcher_for(fen: &str) -> (Board, TranspositionTable) {
+    fn searcher_for(fen: &str) -> (Board, VecTt) {
         let board = Board::from_fen(fen).unwrap();
-        let table = TranspositionTable::new();
+        let table = VecTt::new();
         (board, table)
     }
 
     fn best(fen: &str, depth: i32) -> String {
-        let (mut board, mut table) = searcher_for(fen);
-        let mut searcher = Searcher::new(&mut table);
+        let (mut board, table) = searcher_for(fen);
+        let mut searcher = Searcher::new(&table);
         searcher
             .best_move(&mut board, depth)
             .expect("a legal move exists")
@@ -546,8 +547,8 @@ mod tests {
     }
 
     fn run_search(fen: &str, limits: SearchLimits) -> SearchResult {
-        let (mut board, mut table) = searcher_for(fen);
-        let mut searcher = Searcher::new(&mut table);
+        let (mut board, table) = searcher_for(fen);
+        let mut searcher = Searcher::new(&table);
         searcher.search(&mut board, &limits, Instant::now())
     }
 
@@ -564,8 +565,8 @@ mod tests {
         let net = crate::nnue::test_network();
         let castling = "r3k2r/pppqbppp/2npbn2/4p3/4P3/2NPBN2/PPPQBPPP/R3K2R w KQkq - 0 1";
         for fen in [STARTPOS, MIDGAME, castling] {
-            let (mut board, mut table) = searcher_for(fen);
-            let mv = Searcher::new(&mut table)
+            let (mut board, table) = searcher_for(fen);
+            let mv = Searcher::new(&table)
                 .with_eval_net(Some(&net))
                 .best_move(&mut board, 4)
                 .expect("a legal move exists");
@@ -826,12 +827,12 @@ mod tests {
     #[test]
     fn a_warm_table_reduces_nodes() {
         fn nodes(fen: &str, depth: i32, warm: bool) -> u64 {
-            let (mut board, mut table) = searcher_for(fen);
+            let (mut board, table) = searcher_for(fen);
             if warm {
-                let mut warmup = Searcher::new(&mut table);
+                let mut warmup = Searcher::new(&table);
                 warmup.best_move(&mut board, depth - 1);
             }
-            let mut searcher = Searcher::new(&mut table);
+            let mut searcher = Searcher::new(&table);
             searcher.best_move(&mut board, depth);
             searcher.nodes
         }
@@ -845,8 +846,8 @@ mod tests {
     #[test]
     fn killers_and_history_update_on_a_quiet_cutoff() {
         let mut board = Board::from_fen("4k3/8/8/8/8/8/8/R3K3 w - - 0 1").unwrap();
-        let mut table = TranspositionTable::new();
-        let mut searcher = Searcher::new(&mut table);
+        let table = VecTt::new();
+        let mut searcher = Searcher::new(&table);
 
         // AC-3.1: a new Searcher starts empty.
         assert!(searcher.killers.iter().all(|slot| *slot == [None, None]));
@@ -879,8 +880,8 @@ mod tests {
     fn history_accumulates_across_iterations() {
         // AC-3.2: the table fills as iterative deepening runs.
         let mut board = Board::from_fen(MIDGAME).unwrap();
-        let mut table = TranspositionTable::new();
-        let mut searcher = Searcher::new(&mut table);
+        let table = VecTt::new();
+        let mut searcher = Searcher::new(&table);
         searcher.search(
             &mut board,
             &SearchLimits {
@@ -890,5 +891,58 @@ mod tests {
             Instant::now(),
         );
         assert!(searcher.history.iter().any(|&score| score > 0));
+    }
+
+    // --- Parallel search Wave 1: the Threads=1 determinism basis (AC-2.2) ---
+
+    /// A node-limited search over a fixed position set. Node counts are pure
+    /// logic (not timing), so the `(best_move, nodes)` pairs are reproducible
+    /// across machines — the basis a `Threads=1` engine must match bit-for-bit.
+    const DETERMINISM_POSITIONS: [&str; 6] = [
+        STARTPOS,
+        MIDGAME,
+        "1r3rk1/p1p3pp/3bp3/1p1P1q2/P3pP2/2B1P2P/1P4Q1/4K1NR b K - 0 1",
+        "1r1qr3/pppbbQ1k/2n1p1p1/2PpP3/3P4/2P2N2/P1B2PP1/1RB1K3 b - - 0 1",
+        "2r3k1/6p1/5p1p/p2r4/3p4/6B1/PPP2PPP/R3R1K1 w - - 0 1",
+        "r5rk/5p1p/5R2/4B3/8/8/7P/7K w",
+    ];
+
+    fn determinism_baseline() -> Vec<(String, u64)> {
+        DETERMINISM_POSITIONS
+            .iter()
+            .map(|fen| {
+                let result = run_search(
+                    fen,
+                    SearchLimits {
+                        max_depth: 64,
+                        node_limit: Some(20_000),
+                        ..Default::default()
+                    },
+                );
+                (
+                    result.best_move.map(|mv| mv.to_uci()).unwrap_or_default(),
+                    result.nodes,
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn threads_one_search_is_bit_identical() {
+        // Captured on the single-`&mut TranspositionTable` engine before the
+        // generic-TT refactor. `Searcher<VecTt>` (Threads=1) must reproduce it.
+        let expected = [
+            ("b1c3", 20_000),
+            ("b1c3", 20_000),
+            ("f8f7", 20_000),
+            ("h7h8", 2_650),
+            ("a1c1", 20_000),
+            ("f6a6", 190),
+        ];
+        let expected: Vec<(String, u64)> = expected
+            .iter()
+            .map(|(mv, nodes)| (mv.to_string(), *nodes))
+            .collect();
+        assert_eq!(determinism_baseline(), expected);
     }
 }

--- a/core/src/search.rs
+++ b/core/src/search.rs
@@ -2,6 +2,7 @@
 //! transposition table, mate-distance scoring, and a triangular principal
 //! variation. Deepens one ply at a time within a time budget.
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 use crate::board::Board;
@@ -80,6 +81,10 @@ pub struct Searcher<'a, Tt: TranspositionTable> {
     deadline: Option<Instant>,
     node_limit: Option<u64>,
     stopped: bool,
+    /// Set when running as a parallel worker: a stop flag shared with peer workers
+    /// so they halt together when the budget expires. `None` single-threaded, which
+    /// keeps `should_stop` — and the whole `Threads = 1` path — bit-identical.
+    shared_stop: Option<&'a AtomicBool>,
     /// Triangular table: `pv_table[ply]` is the principal variation from `ply`.
     pv_table: Vec<Vec<Move>>,
     /// The NNUE network, when one is loaded; otherwise the hand-written
@@ -93,6 +98,20 @@ pub struct Searcher<'a, Tt: TranspositionTable> {
 
 impl<'a, Tt: TranspositionTable> Searcher<'a, Tt> {
     pub fn new(transposition_table: &'a Tt) -> Searcher<'a, Tt> {
+        Searcher::with_optional_stop(transposition_table, None)
+    }
+
+    /// A worker for the parallel coordinator: it shares `shared_stop` with its peers
+    /// so they all halt together once one of them reaches the budget.
+    #[allow(dead_code)] // the coordinator wires this in; reached via the Threads option in Wave 4
+    fn new_worker(transposition_table: &'a Tt, shared_stop: &'a AtomicBool) -> Searcher<'a, Tt> {
+        Searcher::with_optional_stop(transposition_table, Some(shared_stop))
+    }
+
+    fn with_optional_stop(
+        transposition_table: &'a Tt,
+        shared_stop: Option<&'a AtomicBool>,
+    ) -> Searcher<'a, Tt> {
         crate::attacks::warm();
         Searcher {
             transposition_table,
@@ -103,6 +122,7 @@ impl<'a, Tt: TranspositionTable> Searcher<'a, Tt> {
             deadline: None,
             node_limit: None,
             stopped: false,
+            shared_stop,
             pv_table: vec![Vec::new(); MAX_SEARCH_PLY],
             eval_net: None,
             accumulator: None,
@@ -247,6 +267,14 @@ impl<'a, Tt: TranspositionTable> Searcher<'a, Tt> {
         if self.stopped {
             return true;
         }
+        // A peer worker reached the budget and signalled; stop with them. `None`
+        // single-threaded, so this branch is inert and the path stays bit-identical.
+        if let Some(shared_stop) = self.shared_stop {
+            if shared_stop.load(Ordering::Relaxed) {
+                self.stopped = true;
+                return true;
+            }
+        }
         // The node budget is checked every node (not batched), so even a tiny limit
         // binds exactly; the clock is polled in batches to amortize `Instant::now`.
         if let Some(limit) = self.node_limit {
@@ -259,6 +287,10 @@ impl<'a, Tt: TranspositionTable> Searcher<'a, Tt> {
             if let Some(deadline) = self.deadline {
                 if Instant::now() >= deadline {
                     self.stopped = true;
+                    // Signal peer workers so they stop at their next check.
+                    if let Some(shared_stop) = self.shared_stop {
+                        shared_stop.store(true, Ordering::Relaxed);
+                    }
                 }
             }
         }
@@ -456,6 +488,49 @@ impl<'a, Tt: TranspositionTable> Searcher<'a, Tt> {
     }
 }
 
+/// Lazy SMP: run `thread_count` independent searches that share one transposition
+/// table and return thread 0's result. Each worker runs the unchanged
+/// iterative-deepening loop on its own cloned `Board` and per-worker state; the
+/// workers share only the table (by `&`), the deadline (each computes the same one
+/// from `limits` and `now`), and a stop flag so they halt together. The reported
+/// `nodes` is the workers' sum (UCI `info nodes`).
+///
+/// The table must be `Sync`, so only `LocklessTranspositionTable` reaches this
+/// path; the single-threaded `ExclusiveTranspositionTable` is `!Sync` and cannot.
+#[allow(dead_code)] // reached once the Threads option selects it in Wave 4
+pub fn search_parallel<Tt: TranspositionTable + Sync>(
+    board: &Board,
+    limits: &SearchLimits,
+    now: Instant,
+    transposition_table: &Tt,
+    thread_count: usize,
+) -> SearchResult {
+    let shared_stop = AtomicBool::new(false);
+    std::thread::scope(|scope| {
+        let workers: Vec<_> = (0..thread_count.max(1))
+            .map(|_| {
+                let mut worker_board = board.clone();
+                let shared_stop = &shared_stop;
+                scope.spawn(move || {
+                    let mut searcher = Searcher::new_worker(transposition_table, shared_stop);
+                    searcher.search(&mut worker_board, limits, now)
+                })
+            })
+            .collect();
+        let results: Vec<SearchResult> = workers
+            .into_iter()
+            .map(|worker| worker.join().expect("a search worker panicked"))
+            .collect();
+        let total_nodes: u64 = results.iter().map(|result| result.nodes).sum();
+        let mut result = results
+            .into_iter()
+            .next()
+            .expect("thread_count is at least 1");
+        result.nodes = total_nodes;
+        result
+    })
+}
+
 pub fn is_mate_score(score: i32) -> bool {
     score.abs() >= MATE_THRESHOLD
 }
@@ -529,7 +604,7 @@ fn compute_budget_ms(side: Color, limits: &SearchLimits) -> Option<u64> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tt::ExclusiveTranspositionTable;
+    use crate::tt::{ExclusiveTranspositionTable, LocklessTranspositionTable};
 
     fn searcher_for(fen: &str) -> (Board, ExclusiveTranspositionTable) {
         let board = Board::from_fen(fen).unwrap();
@@ -945,5 +1020,71 @@ mod tests {
             .map(|(mv, nodes)| (mv.to_string(), *nodes))
             .collect();
         assert_eq!(determinism_baseline(), expected);
+    }
+
+    // --- Parallel search Wave 3: the Lazy SMP coordinator ---
+
+    fn parallel_depth_four(fen: &str, threads: usize) -> SearchResult {
+        let table = LocklessTranspositionTable::new();
+        let board = Board::from_fen(fen).unwrap();
+        let limits = SearchLimits {
+            max_depth: 4,
+            ..Default::default()
+        };
+        search_parallel(&board, &limits, Instant::now(), &table, threads)
+    }
+
+    #[test]
+    fn parallel_search_returns_thread_zero_legal_move() {
+        // AC-1.1, AC-1.2: workers share one table; thread 0's move (and its PV head)
+        // come back, and the move is legal in the root position.
+        let result = parallel_depth_four(MIDGAME, 4);
+        let best = result.best_move.expect("a legal move");
+        let mut board = Board::from_fen(MIDGAME).unwrap();
+        assert!(generate_legal(&mut board).contains(&best));
+        assert_eq!(result.principal_variation.first().copied(), Some(best));
+    }
+
+    #[test]
+    fn parallel_search_stops_within_the_budget() {
+        // AC-1.3: the shared deadline halts every worker and the coordinator returns
+        // a completed iteration's move promptly.
+        let table = LocklessTranspositionTable::new();
+        let board = Board::from_fen(MIDGAME).unwrap();
+        let limits = SearchLimits {
+            max_depth: 64,
+            move_time_ms: Some(200),
+            ..Default::default()
+        };
+        let result = search_parallel(&board, &limits, Instant::now(), &table, 4);
+        assert!(result.best_move.is_some());
+        assert!(result.elapsed_ms < 2_000, "elapsed {}", result.elapsed_ms);
+    }
+
+    #[test]
+    fn parallel_search_finds_the_forced_mate() {
+        // Correctness through the shared table: thread 0 still proves the mate.
+        let result = parallel_depth_four("r5rk/5p1p/5R2/4B3/8/8/7P/7K w", 4);
+        assert!(is_mate_score(result.score), "score {}", result.score);
+    }
+
+    #[test]
+    fn parallel_search_sums_worker_nodes() {
+        // AC-5.2: the reported `nodes` is the workers' sum, so four workers report at
+        // least as many nodes as a single-threaded search of the same position.
+        let parallel = parallel_depth_four(MIDGAME, 4);
+        let single = run_search(
+            MIDGAME,
+            SearchLimits {
+                max_depth: 4,
+                ..Default::default()
+            },
+        );
+        assert!(
+            parallel.nodes >= single.nodes,
+            "parallel {} single {}",
+            parallel.nodes,
+            single.nodes
+        );
     }
 }

--- a/core/src/search.rs
+++ b/core/src/search.rs
@@ -564,19 +564,43 @@ pub fn search_parallel<Tt: TranspositionTable + Sync>(
 /// voting). A worker reporting a nearer mate carries the higher score, so it
 /// outvotes a deeper non-mate; ties break toward greater depth.
 fn vote(results: Vec<SearchResult>) -> SearchResult {
-    let min_score = i64::from(results.iter().map(|result| result.score).min().unwrap_or(0));
+    // A forced mate for us is decisive at any depth — prefer the nearest (highest
+    // score). This guards the one case where a shallow worker should win.
+    if let Some(index) = results
+        .iter()
+        .enumerate()
+        .filter(|(_, worker)| worker.score >= MATE_THRESHOLD)
+        .max_by_key(|(_, worker)| worker.score)
+        .map(|(index, _)| index)
+    {
+        return results.into_iter().nth(index).expect("index is valid");
+    }
+
+    // Otherwise only the deepest workers vote: a shallower search must never
+    // override a deeper one (which loses Elo). Among the deepest, the move the
+    // workers most agree on wins, weighted by score; ties break toward depth.
+    let max_depth = results.iter().map(|result| result.depth).max().unwrap_or(0);
+    let min_score = i64::from(
+        results
+            .iter()
+            .filter(|worker| worker.depth == max_depth)
+            .map(|worker| worker.score)
+            .min()
+            .unwrap_or(0),
+    );
     let mut best_index = 0;
-    let mut best_key = (i64::MIN, i32::MIN);
+    let mut best_votes = i64::MIN;
     for (index, candidate) in results.iter().enumerate() {
+        if candidate.depth != max_depth {
+            continue;
+        }
         let move_votes: i64 = results
             .iter()
-            .filter(|worker| worker.best_move == candidate.best_move)
-            .map(|worker| {
-                (i64::from(worker.score) - min_score + 1) * i64::from(worker.depth.max(1))
-            })
+            .filter(|worker| worker.depth == max_depth && worker.best_move == candidate.best_move)
+            .map(|worker| i64::from(worker.score) - min_score + 1)
             .sum();
-        if (move_votes, candidate.depth) > best_key {
-            best_key = (move_votes, candidate.depth);
+        if move_votes > best_votes {
+            best_votes = move_votes;
             best_index = index;
         }
     }
@@ -1175,14 +1199,15 @@ mod tests {
     }
 
     #[test]
-    fn vote_picks_the_agreed_move_over_a_lone_deeper_worker() {
-        // AC-7.3: not thread 0, not merely the deepest — depth/score-weighted
-        // agreement. Worker 0 is a lone deeper worker on move 20; three agree on 10.
+    fn vote_agrees_among_the_deepest_and_ignores_shallow_workers() {
+        // AC-7.3: among the deepest workers (depth 12) the agreed move 10 beats the
+        // lone move 20 at equal score; the shallow worker (depth 8, huge score) must
+        // NOT override a deeper search — the bug that cost -147 Elo.
         let winner = vote(vec![
-            result(Some(Move(20)), 40, 14),
+            result(Some(Move(30)), 999, 8),
             result(Some(Move(10)), 50, 12),
             result(Some(Move(10)), 50, 12),
-            result(Some(Move(10)), 50, 11),
+            result(Some(Move(20)), 50, 12),
         ]);
         assert_eq!(winner.best_move, Some(Move(10)));
     }

--- a/core/src/search.rs
+++ b/core/src/search.rs
@@ -529,11 +529,11 @@ fn compute_budget_ms(side: Color, limits: &SearchLimits) -> Option<u64> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tt::VecTt;
+    use crate::tt::ExclusiveTranspositionTable;
 
-    fn searcher_for(fen: &str) -> (Board, VecTt) {
+    fn searcher_for(fen: &str) -> (Board, ExclusiveTranspositionTable) {
         let board = Board::from_fen(fen).unwrap();
-        let table = VecTt::new();
+        let table = ExclusiveTranspositionTable::new();
         (board, table)
     }
 
@@ -846,7 +846,7 @@ mod tests {
     #[test]
     fn killers_and_history_update_on_a_quiet_cutoff() {
         let mut board = Board::from_fen("4k3/8/8/8/8/8/8/R3K3 w - - 0 1").unwrap();
-        let table = VecTt::new();
+        let table = ExclusiveTranspositionTable::new();
         let mut searcher = Searcher::new(&table);
 
         // AC-3.1: a new Searcher starts empty.
@@ -880,7 +880,7 @@ mod tests {
     fn history_accumulates_across_iterations() {
         // AC-3.2: the table fills as iterative deepening runs.
         let mut board = Board::from_fen(MIDGAME).unwrap();
-        let table = VecTt::new();
+        let table = ExclusiveTranspositionTable::new();
         let mut searcher = Searcher::new(&table);
         searcher.search(
             &mut board,
@@ -930,7 +930,8 @@ mod tests {
     #[test]
     fn threads_one_search_is_bit_identical() {
         // Captured on the single-`&mut TranspositionTable` engine before the
-        // generic-TT refactor. `Searcher<VecTt>` (Threads=1) must reproduce it.
+        // generic-TT refactor. `Searcher<ExclusiveTranspositionTable>`
+        // (Threads=1) must reproduce it.
         let expected = [
             ("b1c3", 20_000),
             ("b1c3", 20_000),

--- a/core/src/search.rs
+++ b/core/src/search.rs
@@ -35,6 +35,11 @@ const MAX_BUDGET_PERCENT: u64 = 40;
 const MAX_SEARCH_PLY: usize = 128;
 /// Clamp history scores to keep them bounded and ordering stable.
 const HISTORY_MAX: i32 = 1 << 24;
+/// Per-helper depth-skip schedule (Stockfish `SkipSize`/`SkipPhase`, `search.cpp`):
+/// helper `i` skips root depth `d` when `((d + SKIP_PHASE[j]) / SKIP_SIZE[j])` is odd,
+/// `j = (i − 1) mod 20`, fanning the workers across plies (Wave 6 search diversity).
+const SKIP_SIZE: [i32; 20] = [1, 1, 2, 2, 2, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4];
+const SKIP_PHASE: [i32; 20] = [0, 1, 0, 1, 2, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 
 /// The limits for one search. All times are milliseconds.
 #[derive(Clone, Copy, Default)]
@@ -85,6 +90,10 @@ pub struct Searcher<'a, Tt: TranspositionTable> {
     /// so they halt together when the budget expires. `None` single-threaded, which
     /// keeps `should_stop` — and the whole `Threads = 1` path — bit-identical.
     shared_stop: Option<&'a AtomicBool>,
+    /// Worker index for depth staggering (Wave 6): 0 is the main worker (and the
+    /// single-threaded path), which never skips a depth; helpers `> 0` follow the
+    /// skip schedule so the workers search different plies.
+    skip_index: usize,
     /// Triangular table: `pv_table[ply]` is the principal variation from `ply`.
     pv_table: Vec<Vec<Move>>,
     /// The NNUE network, when one is loaded; otherwise the hand-written
@@ -103,8 +112,25 @@ impl<'a, Tt: TranspositionTable> Searcher<'a, Tt> {
 
     /// A worker for the parallel coordinator: it shares `shared_stop` with its peers
     /// so they all halt together once one of them reaches the budget.
-    fn new_worker(transposition_table: &'a Tt, shared_stop: &'a AtomicBool) -> Searcher<'a, Tt> {
-        Searcher::with_optional_stop(transposition_table, Some(shared_stop))
+    fn new_worker(
+        transposition_table: &'a Tt,
+        shared_stop: &'a AtomicBool,
+        skip_index: usize,
+    ) -> Searcher<'a, Tt> {
+        let mut searcher = Searcher::with_optional_stop(transposition_table, Some(shared_stop));
+        searcher.skip_index = skip_index;
+        searcher
+    }
+
+    /// Whether this worker skips iterative-deepening `depth` (Wave 6 staggering).
+    /// Worker 0, the single-threaded path, and the mandatory first ply never skip,
+    /// so every worker keeps a completed result and `Threads = 1` is bit-identical.
+    fn should_skip(&self, depth: i32) -> bool {
+        if self.skip_index == 0 || depth <= 1 {
+            return false;
+        }
+        let j = (self.skip_index - 1) % SKIP_SIZE.len();
+        ((depth + SKIP_PHASE[j]) / SKIP_SIZE[j]) % 2 == 1
     }
 
     fn with_optional_stop(
@@ -122,6 +148,7 @@ impl<'a, Tt: TranspositionTable> Searcher<'a, Tt> {
             node_limit: None,
             stopped: false,
             shared_stop,
+            skip_index: 0,
             pv_table: vec![Vec::new(); MAX_SEARCH_PLY],
             eval_net: None,
             accumulator: None,
@@ -202,6 +229,9 @@ impl<'a, Tt: TranspositionTable> Searcher<'a, Tt> {
         };
 
         for depth in 1..=max_depth {
+            if self.should_skip(depth) {
+                continue; // a helper worker staggers onto other depths (Wave 6)
+            }
             let (best_move, score) = self.negamax(board, depth, -MATE, MATE, 0);
             if self.stopped {
                 break; // discard this incomplete iteration
@@ -507,12 +537,13 @@ pub fn search_parallel<Tt: TranspositionTable + Sync>(
     let shared_stop = AtomicBool::new(false);
     std::thread::scope(|scope| {
         let workers: Vec<_> = (0..thread_count.max(1))
-            .map(|_| {
+            .map(|index| {
                 let mut worker_board = board.clone();
                 let shared_stop = &shared_stop;
                 scope.spawn(move || {
-                    let mut searcher = Searcher::new_worker(transposition_table, shared_stop)
-                        .with_eval_net(eval_net);
+                    let mut searcher =
+                        Searcher::new_worker(transposition_table, shared_stop, index)
+                            .with_eval_net(eval_net);
                     searcher.search(&mut worker_board, limits, now)
                 })
             })
@@ -522,13 +553,37 @@ pub fn search_parallel<Tt: TranspositionTable + Sync>(
             .map(|worker| worker.join().expect("a search worker panicked"))
             .collect();
         let total_nodes: u64 = results.iter().map(|result| result.nodes).sum();
-        let mut result = results
-            .into_iter()
-            .next()
-            .expect("thread_count is at least 1");
+        let mut result = vote(results);
         result.nodes = total_nodes;
         result
     })
+}
+
+/// Pick the move the workers most agree on, weighted by each worker's depth and
+/// score, and return the deepest worker proposing it (Stockfish best-thread
+/// voting). A worker reporting a nearer mate carries the higher score, so it
+/// outvotes a deeper non-mate; ties break toward greater depth.
+fn vote(results: Vec<SearchResult>) -> SearchResult {
+    let min_score = i64::from(results.iter().map(|result| result.score).min().unwrap_or(0));
+    let mut best_index = 0;
+    let mut best_key = (i64::MIN, i32::MIN);
+    for (index, candidate) in results.iter().enumerate() {
+        let move_votes: i64 = results
+            .iter()
+            .filter(|worker| worker.best_move == candidate.best_move)
+            .map(|worker| {
+                (i64::from(worker.score) - min_score + 1) * i64::from(worker.depth.max(1))
+            })
+            .sum();
+        if (move_votes, candidate.depth) > best_key {
+            best_key = (move_votes, candidate.depth);
+            best_index = index;
+        }
+    }
+    results
+        .into_iter()
+        .nth(best_index)
+        .expect("thread_count is at least 1")
 }
 
 pub fn is_mate_score(score: i32) -> bool {
@@ -1086,5 +1141,59 @@ mod tests {
             parallel.nodes,
             single.nodes
         );
+    }
+
+    // --- Parallel search Wave 6: depth staggering + thread voting ---
+
+    #[test]
+    fn staggering_keeps_the_main_worker_complete_and_skips_helper_depths() {
+        // AC-7.1–7.2: worker 0 never skips; a helper skips some depths but never the
+        // first ply, so every worker keeps a completed result.
+        let table = ExclusiveTranspositionTable::new();
+        let stop = std::sync::atomic::AtomicBool::new(false);
+        let main = Searcher::new_worker(&table, &stop, 0);
+        let helper = Searcher::new_worker(&table, &stop, 3);
+        for depth in 1..=12 {
+            assert!(!main.should_skip(depth), "the main worker never skips");
+        }
+        assert!(!helper.should_skip(1), "no worker skips the first ply");
+        assert!(
+            (2..=12).any(|depth| helper.should_skip(depth)),
+            "a helper must skip some depth to diversify"
+        );
+    }
+
+    fn result(best_move: Option<Move>, score: i32, depth: i32) -> SearchResult {
+        SearchResult {
+            best_move,
+            score,
+            depth,
+            nodes: 0,
+            elapsed_ms: 0,
+            principal_variation: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn vote_picks_the_agreed_move_over_a_lone_deeper_worker() {
+        // AC-7.3: not thread 0, not merely the deepest — depth/score-weighted
+        // agreement. Worker 0 is a lone deeper worker on move 20; three agree on 10.
+        let winner = vote(vec![
+            result(Some(Move(20)), 40, 14),
+            result(Some(Move(10)), 50, 12),
+            result(Some(Move(10)), 50, 12),
+            result(Some(Move(10)), 50, 11),
+        ]);
+        assert_eq!(winner.best_move, Some(Move(10)));
+    }
+
+    #[test]
+    fn vote_prefers_a_nearer_mate_to_a_deeper_non_mate() {
+        // AC-7.4: a worker reporting a forced mate outvotes a deeper non-mate.
+        let winner = vote(vec![
+            result(Some(Move(20)), 600, 20),
+            result(Some(Move(10)), MATE - 5, 8),
+        ]);
+        assert_eq!(winner.best_move, Some(Move(10)));
     }
 }

--- a/core/src/search.rs
+++ b/core/src/search.rs
@@ -103,7 +103,6 @@ impl<'a, Tt: TranspositionTable> Searcher<'a, Tt> {
 
     /// A worker for the parallel coordinator: it shares `shared_stop` with its peers
     /// so they all halt together once one of them reaches the budget.
-    #[allow(dead_code)] // the coordinator wires this in; reached via the Threads option in Wave 4
     fn new_worker(transposition_table: &'a Tt, shared_stop: &'a AtomicBool) -> Searcher<'a, Tt> {
         Searcher::with_optional_stop(transposition_table, Some(shared_stop))
     }
@@ -497,13 +496,13 @@ impl<'a, Tt: TranspositionTable> Searcher<'a, Tt> {
 ///
 /// The table must be `Sync`, so only `LocklessTranspositionTable` reaches this
 /// path; the single-threaded `ExclusiveTranspositionTable` is `!Sync` and cannot.
-#[allow(dead_code)] // reached once the Threads option selects it in Wave 4
 pub fn search_parallel<Tt: TranspositionTable + Sync>(
     board: &Board,
     limits: &SearchLimits,
     now: Instant,
     transposition_table: &Tt,
     thread_count: usize,
+    eval_net: Option<&Network>,
 ) -> SearchResult {
     let shared_stop = AtomicBool::new(false);
     std::thread::scope(|scope| {
@@ -512,7 +511,8 @@ pub fn search_parallel<Tt: TranspositionTable + Sync>(
                 let mut worker_board = board.clone();
                 let shared_stop = &shared_stop;
                 scope.spawn(move || {
-                    let mut searcher = Searcher::new_worker(transposition_table, shared_stop);
+                    let mut searcher = Searcher::new_worker(transposition_table, shared_stop)
+                        .with_eval_net(eval_net);
                     searcher.search(&mut worker_board, limits, now)
                 })
             })
@@ -1031,7 +1031,7 @@ mod tests {
             max_depth: 4,
             ..Default::default()
         };
-        search_parallel(&board, &limits, Instant::now(), &table, threads)
+        search_parallel(&board, &limits, Instant::now(), &table, threads, None)
     }
 
     #[test]
@@ -1056,7 +1056,7 @@ mod tests {
             move_time_ms: Some(200),
             ..Default::default()
         };
-        let result = search_parallel(&board, &limits, Instant::now(), &table, 4);
+        let result = search_parallel(&board, &limits, Instant::now(), &table, 4, None);
         assert!(result.best_move.is_some());
         assert!(result.elapsed_ms < 2_000, "elapsed {}", result.elapsed_ms);
     }

--- a/core/src/tt.rs
+++ b/core/src/tt.rs
@@ -1,5 +1,9 @@
 //! TranspositionTable — a Zobrist-keyed cache of evaluated positions, a port of
 //! `src/transposition_table.py` with the same replace-by-depth-and-age policy.
+//! The cache is a trait with two backends: `VecTt` for single-threaded search
+//! (`Threads = 1`) and, later, a lockless atomic table for parallel search.
+
+use std::cell::RefCell;
 
 use crate::chess_move::Move;
 
@@ -24,49 +28,72 @@ pub struct HashEntry {
 /// 2^20 + 7 (prime), matching the original.
 const TABLE_SIZE: usize = 1_048_583;
 
-pub struct TranspositionTable {
-    table: Vec<Option<HashEntry>>,
-}
-
-impl Default for TranspositionTable {
-    fn default() -> Self {
-        TranspositionTable::new()
-    }
-}
-
-impl TranspositionTable {
-    pub fn new() -> TranspositionTable {
-        TranspositionTable {
-            table: vec![None; TABLE_SIZE],
-        }
-    }
-
-    /// Store `entry` if the slot is empty, the new entry is newer (greater age),
-    /// or it was searched deeper.
-    pub fn replace(&mut self, entry: HashEntry) {
-        let index = (entry.zobrist % TABLE_SIZE as u64) as usize;
-        let should_replace = match self.table[index] {
-            None => true,
-            Some(stored) => entry.age > stored.age || entry.depth > stored.depth,
-        };
-        if should_replace {
-            self.table[index] = Some(entry);
-        }
-    }
-
+/// A Zobrist-keyed cache of evaluated positions. `probe` and `replace` take
+/// `&self` so one table can back several searches at once; the backend supplies
+/// the synchronization (`RefCell` for the single-threaded `VecTt`, atomics for
+/// the lockless parallel table). The Searcher is generic over this trait, so the
+/// backend is chosen once at search entry with no per-node virtual call.
+pub trait TranspositionTable {
     /// The stored entry whose key matches, regardless of depth. The search
     /// decides whether the entry is deep enough to cut; even a shallow entry
     /// seeds move ordering with its best Move.
-    pub fn probe(&self, zobrist: u64) -> Option<HashEntry> {
+    fn probe(&self, zobrist: u64) -> Option<HashEntry>;
+
+    /// Store `entry` if the slot is empty, the new entry is newer (greater age),
+    /// or it was searched deeper.
+    fn replace(&self, entry: HashEntry);
+}
+
+/// The single-threaded backend: today's `Vec` slot table behind `RefCell`
+/// interior mutability. Used for `Threads = 1`; with one thread the borrow
+/// always succeeds, so it is bit-identical to the original engine.
+pub struct VecTt {
+    table: RefCell<Vec<Option<HashEntry>>>,
+}
+
+impl Default for VecTt {
+    fn default() -> Self {
+        VecTt::new()
+    }
+}
+
+impl VecTt {
+    pub fn new() -> VecTt {
+        VecTt {
+            table: RefCell::new(vec![None; TABLE_SIZE]),
+        }
+    }
+
+    /// A point-in-time snapshot of the live entries, for HTTP introspection.
+    /// Returns owned entries because the slots sit behind a `RefCell` borrow.
+    pub fn entries(&self) -> Vec<HashEntry> {
+        self.table
+            .borrow()
+            .iter()
+            .filter_map(|slot| *slot)
+            .collect()
+    }
+}
+
+impl TranspositionTable for VecTt {
+    fn probe(&self, zobrist: u64) -> Option<HashEntry> {
         let index = (zobrist % TABLE_SIZE as u64) as usize;
-        match self.table[index] {
+        match self.table.borrow()[index] {
             Some(stored) if stored.zobrist == zobrist => Some(stored),
             _ => None,
         }
     }
 
-    pub fn entries(&self) -> impl Iterator<Item = &HashEntry> {
-        self.table.iter().filter_map(|slot| slot.as_ref())
+    fn replace(&self, entry: HashEntry) {
+        let index = (entry.zobrist % TABLE_SIZE as u64) as usize;
+        let mut table = self.table.borrow_mut();
+        let should_replace = match table[index] {
+            None => true,
+            Some(stored) => entry.age > stored.age || entry.depth > stored.depth,
+        };
+        if should_replace {
+            table[index] = Some(entry);
+        }
     }
 }
 
@@ -87,7 +114,7 @@ mod tests {
 
     #[test]
     fn stores_into_an_empty_slot() {
-        let mut table = TranspositionTable::new();
+        let table = VecTt::new();
         let stored = entry(5, 0);
         table.replace(stored);
         assert_eq!(table.probe(0xABCD), Some(stored));
@@ -95,7 +122,7 @@ mod tests {
 
     #[test]
     fn replaces_when_age_is_greater() {
-        let mut table = TranspositionTable::new();
+        let table = VecTt::new();
         table.replace(entry(5, 0));
         let newer = entry(5, 2);
         table.replace(newer);
@@ -104,7 +131,7 @@ mod tests {
 
     #[test]
     fn replaces_when_depth_is_greater_and_age_equal() {
-        let mut table = TranspositionTable::new();
+        let table = VecTt::new();
         table.replace(entry(4, 0));
         let deeper = entry(5, 0);
         table.replace(deeper);
@@ -113,7 +140,7 @@ mod tests {
 
     #[test]
     fn keeps_entry_when_depth_is_lesser_and_age_equal() {
-        let mut table = TranspositionTable::new();
+        let table = VecTt::new();
         let deeper = entry(5, 0);
         table.replace(deeper);
         table.replace(entry(4, 0));

--- a/core/src/tt.rs
+++ b/core/src/tt.rs
@@ -1,10 +1,11 @@
 //! TranspositionTable — a Zobrist-keyed cache of evaluated positions, a port of
 //! `src/transposition_table.py` with the same replace-by-depth-and-age policy.
 //! The cache is a trait with two backends: `ExclusiveTranspositionTable` for
-//! single-threaded search (`Threads = 1`) and, later, a lockless atomic table
-//! for parallel search.
+//! single-threaded search (`Threads = 1`) and `LocklessTranspositionTable`, a
+//! lockless atomic table, for parallel search (`Threads > 1`).
 
 use std::cell::RefCell;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::chess_move::Move;
 
@@ -99,6 +100,131 @@ impl TranspositionTable for ExclusiveTranspositionTable {
     }
 }
 
+/// The lockless parallel backend (`Threads > 1`): a slot table of atomic word
+/// pairs using Robert Hyatt's key-XOR-data trick. Each `HashEntry` packs into one
+/// 60-bit `data` word and the slot stores `key = zobrist ^ data`, so `probe`
+/// trusts a slot only when `key ^ data` reproduces the probed zobrist. A torn read
+/// — `key` from one store, `data` from another — fails that checksum and reads as
+/// a miss, never a wrong-position hit. No locks on the hot path, no `unsafe`.
+#[allow(dead_code)] // the parallel coordinator constructs this in Wave 3
+pub struct LocklessTranspositionTable {
+    table: Vec<AtomicSlot>,
+}
+
+/// One slot: the `key` checksum and the packed-entry `data`. All-zero is empty.
+#[allow(dead_code)]
+struct AtomicSlot {
+    key: AtomicU64,
+    data: AtomicU64,
+}
+
+#[allow(dead_code)]
+impl AtomicSlot {
+    fn empty() -> AtomicSlot {
+        AtomicSlot {
+            key: AtomicU64::new(0),
+            data: AtomicU64::new(0),
+        }
+    }
+}
+
+#[allow(dead_code)] // reachable once the coordinator constructs the table (Wave 3)
+impl LocklessTranspositionTable {
+    // `data` bit layout, 60 of 64 bits used: best_move 16 | depth 8 | value 18 |
+    // flag 2 | age 16. `best_move` occupies the low bits; 0 is the `None` sentinel
+    // (`a1a1`, never legal).
+    const DEPTH_SHIFT: u32 = 16;
+    const VALUE_SHIFT: u32 = 24;
+    const FLAG_SHIFT: u32 = 42;
+    const AGE_SHIFT: u32 = 44;
+    const MOVE_MASK: u64 = 0xFFFF;
+    const DEPTH_MASK: u64 = 0xFF;
+    const VALUE_MASK: u64 = 0x3_FFFF;
+    const FLAG_MASK: u64 = 0x3;
+    const AGE_MASK: u64 = 0xFFFF;
+    /// Bits the signed `value` field occupies, for sign extension on unpack.
+    const VALUE_BITS: u32 = 18;
+
+    pub fn new() -> LocklessTranspositionTable {
+        LocklessTranspositionTable {
+            table: (0..TABLE_SIZE).map(|_| AtomicSlot::empty()).collect(),
+        }
+    }
+
+    /// Pack a `HashEntry`'s fields (everything but the zobrist) into one 60-bit word.
+    fn pack(entry: HashEntry) -> u64 {
+        let best_move = entry.best_move.map_or(0, |mv| mv.0 as u64);
+        let depth = (entry.depth as i8 as u8) as u64;
+        let value = (entry.value as i64 as u64) & Self::VALUE_MASK;
+        let flag = match entry.flag {
+            Flag::Exact => 0,
+            Flag::LowerBound => 1,
+            Flag::UpperBound => 2,
+        };
+        let age = entry.age as u64;
+        best_move
+            | (depth << Self::DEPTH_SHIFT)
+            | (value << Self::VALUE_SHIFT)
+            | (flag << Self::FLAG_SHIFT)
+            | (age << Self::AGE_SHIFT)
+    }
+
+    /// Decode a packed word; the zobrist is supplied by the caller (not stored).
+    fn unpack(data: u64, zobrist: u64) -> HashEntry {
+        let move_bits = (data & Self::MOVE_MASK) as u16;
+        let best_move = (move_bits != 0).then_some(Move(move_bits));
+        let depth = ((data >> Self::DEPTH_SHIFT) & Self::DEPTH_MASK) as u8 as i8 as i32;
+        // Sign-extend the value: lift its high bit to bit 63, then arithmetic-shift back.
+        let raw = (data >> Self::VALUE_SHIFT) & Self::VALUE_MASK;
+        let value = ((raw << (64 - Self::VALUE_BITS)) as i64 >> (64 - Self::VALUE_BITS)) as i32;
+        let flag = match (data >> Self::FLAG_SHIFT) & Self::FLAG_MASK {
+            0 => Flag::Exact,
+            1 => Flag::LowerBound,
+            _ => Flag::UpperBound,
+        };
+        let age = ((data >> Self::AGE_SHIFT) & Self::AGE_MASK) as u16;
+        HashEntry {
+            zobrist,
+            best_move,
+            depth,
+            value,
+            flag,
+            age,
+        }
+    }
+}
+
+impl Default for LocklessTranspositionTable {
+    fn default() -> Self {
+        LocklessTranspositionTable::new()
+    }
+}
+
+impl TranspositionTable for LocklessTranspositionTable {
+    fn probe(&self, zobrist: u64) -> Option<HashEntry> {
+        let slot = &self.table[(zobrist % TABLE_SIZE as u64) as usize];
+        let data = slot.data.load(Ordering::Relaxed);
+        let key = slot.key.load(Ordering::Relaxed);
+        // The checksum holds only when both words come from the same store.
+        (key ^ data == zobrist).then(|| Self::unpack(data, zobrist))
+    }
+
+    fn replace(&self, entry: HashEntry) {
+        let slot = &self.table[(entry.zobrist % TABLE_SIZE as u64) as usize];
+        let stored = slot.data.load(Ordering::Relaxed);
+        let stored_depth = ((stored >> Self::DEPTH_SHIFT) & Self::DEPTH_MASK) as u8 as i8 as i32;
+        let stored_age = ((stored >> Self::AGE_SHIFT) & Self::AGE_MASK) as u16;
+        // Best-effort replace-by-age-or-depth; an empty (all-zero) slot decodes to
+        // age 0 / depth 0, so any real entry overwrites it. The race is speed-only:
+        // a lost replacement costs nodes, never legality.
+        if entry.age > stored_age || entry.depth > stored_depth {
+            let data = Self::pack(entry);
+            slot.key.store(entry.zobrist ^ data, Ordering::Relaxed);
+            slot.data.store(data, Ordering::Relaxed);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -147,5 +273,90 @@ mod tests {
         table.replace(deeper);
         table.replace(entry(4, 0));
         assert_eq!(table.probe(0xABCD), Some(deeper));
+    }
+
+    // --- Wave 2: the lockless parallel backend ---
+
+    fn full_entry(
+        zobrist: u64,
+        best_move: Option<Move>,
+        depth: i32,
+        value: i32,
+        flag: Flag,
+        age: u16,
+    ) -> HashEntry {
+        HashEntry {
+            zobrist,
+            best_move,
+            depth,
+            value,
+            flag,
+            age,
+        }
+    }
+
+    #[test]
+    fn lockless_entry_round_trips_through_packing() {
+        // Every field survives the 60-bit codec, including a None move, the depth
+        // and value extremes (negative quiescence depth, ±mate), all three flags,
+        // and the full 16-bit age range.
+        let cases = [
+            full_entry(0x1, None, 0, 0, Flag::Exact, 0),
+            full_entry(
+                0x2,
+                Some(Move(0xFFFF)),
+                64,
+                99_999,
+                Flag::LowerBound,
+                65_535,
+            ),
+            full_entry(0x3, Some(Move(1)), -5, -99_999, Flag::UpperBound, 100),
+            full_entry(0x4, Some(Move(0x0ABC)), 12, -54_321, Flag::Exact, 7),
+        ];
+        for entry in cases {
+            let data = LocklessTranspositionTable::pack(entry);
+            assert_eq!(
+                LocklessTranspositionTable::unpack(data, entry.zobrist),
+                entry
+            );
+        }
+    }
+
+    #[test]
+    fn lockless_stores_and_probes() {
+        let table = LocklessTranspositionTable::new();
+        let stored = full_entry(0xDEAD_BEEF, Some(Move(0x1234)), 7, 42, Flag::Exact, 3);
+        table.replace(stored);
+        assert_eq!(table.probe(0xDEAD_BEEF), Some(stored));
+        assert_eq!(table.probe(0xFEED_FACE), None);
+    }
+
+    #[test]
+    fn lockless_rejects_a_torn_read() {
+        // AC-3.2: a torn read — `key` from one store, `data` from another — fails
+        // the key-XOR-data checksum and reads as a miss, never a wrong-position hit.
+        let table = LocklessTranspositionTable::new();
+        let zobrist = 0xDEAD_BEEF;
+        let stored = full_entry(zobrist, Some(Move(0x1234)), 7, 42, Flag::Exact, 3);
+        let intruder = full_entry(zobrist, Some(Move(0x5678)), 9, -88, Flag::LowerBound, 4);
+        table.replace(stored);
+        assert_eq!(table.probe(zobrist), Some(stored));
+        // Overwrite only the data word, leaving the old key: the checksum breaks.
+        let index = (zobrist % TABLE_SIZE as u64) as usize;
+        table.table[index].data.store(
+            LocklessTranspositionTable::pack(intruder),
+            std::sync::atomic::Ordering::Relaxed,
+        );
+        assert_eq!(table.probe(zobrist), None);
+    }
+
+    #[test]
+    fn lockless_keeps_the_deeper_entry() {
+        let table = LocklessTranspositionTable::new();
+        let zobrist = 0x99;
+        let deep = full_entry(zobrist, None, 8, 10, Flag::Exact, 0);
+        table.replace(deep);
+        table.replace(full_entry(zobrist, None, 3, 20, Flag::Exact, 0));
+        assert_eq!(table.probe(zobrist), Some(deep));
     }
 }

--- a/core/src/tt.rs
+++ b/core/src/tt.rs
@@ -1,7 +1,8 @@
 //! TranspositionTable — a Zobrist-keyed cache of evaluated positions, a port of
 //! `src/transposition_table.py` with the same replace-by-depth-and-age policy.
-//! The cache is a trait with two backends: `VecTt` for single-threaded search
-//! (`Threads = 1`) and, later, a lockless atomic table for parallel search.
+//! The cache is a trait with two backends: `ExclusiveTranspositionTable` for
+//! single-threaded search (`Threads = 1`) and, later, a lockless atomic table
+//! for parallel search.
 
 use std::cell::RefCell;
 
@@ -30,9 +31,10 @@ const TABLE_SIZE: usize = 1_048_583;
 
 /// A Zobrist-keyed cache of evaluated positions. `probe` and `replace` take
 /// `&self` so one table can back several searches at once; the backend supplies
-/// the synchronization (`RefCell` for the single-threaded `VecTt`, atomics for
-/// the lockless parallel table). The Searcher is generic over this trait, so the
-/// backend is chosen once at search entry with no per-node virtual call.
+/// the synchronization (`RefCell` for the single-threaded
+/// `ExclusiveTranspositionTable`, atomics for the lockless parallel table). The
+/// Searcher is generic over this trait, so the backend is chosen once at search
+/// entry with no per-node virtual call.
 pub trait TranspositionTable {
     /// The stored entry whose key matches, regardless of depth. The search
     /// decides whether the entry is deep enough to cut; even a shallow entry
@@ -47,19 +49,19 @@ pub trait TranspositionTable {
 /// The single-threaded backend: today's `Vec` slot table behind `RefCell`
 /// interior mutability. Used for `Threads = 1`; with one thread the borrow
 /// always succeeds, so it is bit-identical to the original engine.
-pub struct VecTt {
+pub struct ExclusiveTranspositionTable {
     table: RefCell<Vec<Option<HashEntry>>>,
 }
 
-impl Default for VecTt {
+impl Default for ExclusiveTranspositionTable {
     fn default() -> Self {
-        VecTt::new()
+        ExclusiveTranspositionTable::new()
     }
 }
 
-impl VecTt {
-    pub fn new() -> VecTt {
-        VecTt {
+impl ExclusiveTranspositionTable {
+    pub fn new() -> ExclusiveTranspositionTable {
+        ExclusiveTranspositionTable {
             table: RefCell::new(vec![None; TABLE_SIZE]),
         }
     }
@@ -75,7 +77,7 @@ impl VecTt {
     }
 }
 
-impl TranspositionTable for VecTt {
+impl TranspositionTable for ExclusiveTranspositionTable {
     fn probe(&self, zobrist: u64) -> Option<HashEntry> {
         let index = (zobrist % TABLE_SIZE as u64) as usize;
         match self.table.borrow()[index] {
@@ -114,7 +116,7 @@ mod tests {
 
     #[test]
     fn stores_into_an_empty_slot() {
-        let table = VecTt::new();
+        let table = ExclusiveTranspositionTable::new();
         let stored = entry(5, 0);
         table.replace(stored);
         assert_eq!(table.probe(0xABCD), Some(stored));
@@ -122,7 +124,7 @@ mod tests {
 
     #[test]
     fn replaces_when_age_is_greater() {
-        let table = VecTt::new();
+        let table = ExclusiveTranspositionTable::new();
         table.replace(entry(5, 0));
         let newer = entry(5, 2);
         table.replace(newer);
@@ -131,7 +133,7 @@ mod tests {
 
     #[test]
     fn replaces_when_depth_is_greater_and_age_equal() {
-        let table = VecTt::new();
+        let table = ExclusiveTranspositionTable::new();
         table.replace(entry(4, 0));
         let deeper = entry(5, 0);
         table.replace(deeper);
@@ -140,7 +142,7 @@ mod tests {
 
     #[test]
     fn keeps_entry_when_depth_is_lesser_and_age_equal() {
-        let table = VecTt::new();
+        let table = ExclusiveTranspositionTable::new();
         let deeper = entry(5, 0);
         table.replace(deeper);
         table.replace(entry(4, 0));

--- a/roadmap/BACKLOG.md
+++ b/roadmap/BACKLOG.md
@@ -12,6 +12,5 @@ then it becomes a card on `roadmap/ROADMAP.md`.
 
 | Idea | Why | Source |
 |---|---|---|
-| Parallel search across cores | The engine runs single-threaded; multi-core search would deepen within the same time budget | README TODO |
 | Manage AWS resources with CDK | The `t2.micro` host is configured by hand; infra-as-code makes it reproducible | README TODO |
 | Reinforcement-learning evaluation | Learn the evaluation function instead of hand-tuning piece-square values | README TODO — partly carded as Epic 5 (NNUE, supervised on self-play); a true RL loop (policy/value + MCTS) stays here |

--- a/roadmap/ROADMAP.md
+++ b/roadmap/ROADMAP.md
@@ -156,7 +156,7 @@ not a runtime strategy.
 | Work | Status | Spec | Depends on |
 |---|---|---|---|
 | Generic TranspositionTable backend (@branransom) | Done | [parallel-search](specs/parallel-search/design.md) | Rust engine core |
-| Lockless atomic table (@branransom) | Ready | [parallel-search](specs/parallel-search/design.md) | Generic TranspositionTable backend |
-| Lazy SMP coordinator (@branransom) | Planned | [parallel-search](specs/parallel-search/design.md) | Lockless atomic table |
+| Lockless atomic table (@branransom) | Done | [parallel-search](specs/parallel-search/design.md) | Generic TranspositionTable backend |
+| Lazy SMP coordinator (@branransom) | Ready | [parallel-search](specs/parallel-search/design.md) | Lockless atomic table |
 | Threads option + seam guards (@branransom) | Planned | [parallel-search](specs/parallel-search/design.md) | Lazy SMP coordinator |
 | Measure (time-control SPRT) + docs (@branransom) | Planned | [parallel-search](specs/parallel-search/design.md) | Threads option + seam guards, Fair-match harness + acceptance rule |

--- a/roadmap/ROADMAP.md
+++ b/roadmap/ROADMAP.md
@@ -157,6 +157,6 @@ not a runtime strategy.
 |---|---|---|---|
 | Generic TranspositionTable backend (@branransom) | Done | [parallel-search](specs/parallel-search/design.md) | Rust engine core |
 | Lockless atomic table (@branransom) | Done | [parallel-search](specs/parallel-search/design.md) | Generic TranspositionTable backend |
-| Lazy SMP coordinator (@branransom) | Ready | [parallel-search](specs/parallel-search/design.md) | Lockless atomic table |
-| Threads option + seam guards (@branransom) | Planned | [parallel-search](specs/parallel-search/design.md) | Lazy SMP coordinator |
+| Lazy SMP coordinator (@branransom) | Done | [parallel-search](specs/parallel-search/design.md) | Lockless atomic table |
+| Threads option + seam guards (@branransom) | Ready | [parallel-search](specs/parallel-search/design.md) | Lazy SMP coordinator |
 | Measure (time-control SPRT) + docs (@branransom) | Planned | [parallel-search](specs/parallel-search/design.md) | Threads option + seam guards, Fair-match harness + acceptance rule |

--- a/roadmap/ROADMAP.md
+++ b/roadmap/ROADMAP.md
@@ -144,3 +144,19 @@ integration, is the dominant cost.
 | Incremental accumulator — make/unmake deltas, refresh == incremental, node rate (@bmransom, `feat/nnue-eval`) | Done | [nnue-eval](specs/nnue-eval/design.md) | Borrow the architecture |
 | Measure strength — SPRT vs the PeSTO build: net #3 +115 Elo [+91, +141], accept-H1 (@bmransom, `feat/nnue-eval`) | Done | [nnue-eval](specs/nnue-eval/design.md) | Training pipeline, Incremental accumulator, Fair-match harness + acceptance rule |
 | Docs + glossary + board | Planned | [nnue-eval](specs/nnue-eval/design.md) | Measure strength |
+
+### Epic 6 — Parallel search
+
+Add Lazy SMP — N worker searches sharing one transposition table — so the engine
+deepens within the same time budget. The single-threaded path stays the default
+and bit-identical (the fair-match harness's deterministic basis); the parallel
+speedup is measured at a time control. The TT backend is a monomorphized generic,
+not a runtime strategy.
+
+| Work | Status | Spec | Depends on |
+|---|---|---|---|
+| Generic TranspositionTable backend (@branransom) | Ready | [parallel-search](specs/parallel-search/design.md) | Rust engine core |
+| Lockless atomic table (@branransom) | Planned | [parallel-search](specs/parallel-search/design.md) | Generic TranspositionTable backend |
+| Lazy SMP coordinator (@branransom) | Planned | [parallel-search](specs/parallel-search/design.md) | Lockless atomic table |
+| Threads option + seam guards (@branransom) | Planned | [parallel-search](specs/parallel-search/design.md) | Lazy SMP coordinator |
+| Measure (time-control SPRT) + docs (@branransom) | Planned | [parallel-search](specs/parallel-search/design.md) | Threads option + seam guards, Fair-match harness + acceptance rule |

--- a/roadmap/ROADMAP.md
+++ b/roadmap/ROADMAP.md
@@ -155,8 +155,8 @@ not a runtime strategy.
 
 | Work | Status | Spec | Depends on |
 |---|---|---|---|
-| Generic TranspositionTable backend (@branransom) | Ready | [parallel-search](specs/parallel-search/design.md) | Rust engine core |
-| Lockless atomic table (@branransom) | Planned | [parallel-search](specs/parallel-search/design.md) | Generic TranspositionTable backend |
+| Generic TranspositionTable backend (@branransom) | Done | [parallel-search](specs/parallel-search/design.md) | Rust engine core |
+| Lockless atomic table (@branransom) | Ready | [parallel-search](specs/parallel-search/design.md) | Generic TranspositionTable backend |
 | Lazy SMP coordinator (@branransom) | Planned | [parallel-search](specs/parallel-search/design.md) | Lockless atomic table |
 | Threads option + seam guards (@branransom) | Planned | [parallel-search](specs/parallel-search/design.md) | Lazy SMP coordinator |
 | Measure (time-control SPRT) + docs (@branransom) | Planned | [parallel-search](specs/parallel-search/design.md) | Threads option + seam guards, Fair-match harness + acceptance rule |

--- a/roadmap/specs/parallel-search/design.md
+++ b/roadmap/specs/parallel-search/design.md
@@ -1,6 +1,6 @@
 ---
 title: Parallel search — design
-description: Lazy SMP with a monomorphized generic over two TT backends — today's exclusive VecTt for Threads=1 and a lockless single-u64 AtomicTt for Threads>1.
+description: Lazy SMP with a monomorphized generic over two TranspositionTable backends — an exclusive table for Threads=1 and a lockless single-u64 table for Threads>1.
 ---
 
 > **Status:** Ready — tracked on the [board](../../ROADMAP.md). Derived from the
@@ -31,7 +31,7 @@ runs today's iterative-deepening loop on a **cloned `Board`** (`Board: Clone`) w
 its own `history`, `killers`, `pv_table`, `position_history`, and `nodes`. Workers
 share only:
 
-- the `AtomicTt` (a `&` borrow through the scope),
+- the `LocklessTranspositionTable` (a `&` borrow through the scope),
 - the immutable `deadline`,
 - an `AtomicBool` stop flag,
 - an `AtomicU64` aggregate node counter.
@@ -60,15 +60,15 @@ backend is selected once, cold, at search entry via a monomorphized generic
 ## Two TT backends behind one trait
 
 The `TranspositionTable` becomes a trait — `probe(&self, zobrist) -> Option<HashEntry>`
-and `replace(&self, entry)` — and today's concrete table is renamed `VecTt`, one of
+and `replace(&self, entry)` — and today's concrete table is renamed `ExclusiveTranspositionTable`, one of
 its two implementations. `HashEntry` stays the decoded semantic record.
 
-- **`VecTt`** — today's `Vec<Option<HashEntry>>` with the same replace-by-age-or-depth
+- **`ExclusiveTranspositionTable`** — today's `Vec<Option<HashEntry>>` with the same replace-by-age-or-depth
   policy, used for `Threads = 1`. The `&self` signature gives it interior mutability
   (`RefCell`); with one thread the borrow always succeeds and the behavior is
   identical. Bit-identity is therefore a property of the type, guarded by the
   determinism test — not a packing argument.
-- **`AtomicTt`** — the Hyatt lockless slot `{ key: AtomicU64, data: AtomicU64 }`
+- **`LocklessTranspositionTable`** — the Hyatt key-XOR-data slot `{ key: AtomicU64, data: AtomicU64 }`
   with `key = zobrist ^ data`, used for `Threads > 1`.
 
 **Packing (one u64).** The entry fits in 60 bits — `best_move` 16 (the `0x0000`
@@ -88,7 +88,7 @@ under `Threads > 1` anyway.
 
 ## Determinism and measurement
 
-- **`Threads = 1` is bit-identical** because it instantiates `Searcher<VecTt>` —
+- **`Threads = 1` is bit-identical** because it instantiates `Searcher<ExclusiveTranspositionTable>` —
   today's exact access pattern and policy. The eval-term measurements hold by
   construction; a `(best_move, node_count)` baseline test over a position set guards
   it (extending AC-1.3 of the fair-match harness).
@@ -141,7 +141,7 @@ atomic table, so `/transposition_table` snapshot-decodes the slots; it runs at
   a second word and a `mix()` only widen the torn-read window.
 - **Two concrete code paths** (no generic). Rejected: duplicates the negamax logic;
   the monomorphized generic matches the repo's `Searcher<O: MoveOrderer>` and the
-  determinism guard de-risks the `VecTt` interior-mutability change.
+  determinism guard de-risks the `ExclusiveTranspositionTable` interior-mutability change.
 
 ## Risks
 

--- a/roadmap/specs/parallel-search/design.md
+++ b/roadmap/specs/parallel-search/design.md
@@ -18,7 +18,7 @@ description: Lazy SMP with a monomorphized generic over two TranspositionTable b
 | Backend dispatch | Monomorphized generic `Searcher<Tt>` | The repo's own escape hatch (`Searcher<O: MoveOrderer>`); zero per-node virtual calls. |
 | TT (parallel) | Lockless single-u64 atomic | Hyatt key-XOR-data; no locks on the hot path, no `unsafe`. |
 | `Threads = 1` | Bit-identical to today | The deterministic basis the fair-match harness measures against. |
-| `go nodes` | Forces one thread | The aggregate node counter is a race — node mode is unreproducible with N>1. |
+| `go nodes` | Forces one thread | The summed node count is non-deterministic — node mode is unreproducible with N>1. |
 | Parallel Elo | Time-control SPRT | Fixed-node's premise is determinism, which parallel search abandons. |
 
 ## Lazy SMP coordinator
@@ -32,11 +32,12 @@ its own `history`, `killers`, `pv_table`, `position_history`, and `nodes`. Worke
 share only:
 
 - the `LocklessTranspositionTable` (a `&` borrow through the scope),
-- the immutable `deadline`,
-- an `AtomicBool` stop flag,
-- an `AtomicU64` aggregate node counter.
+- the immutable `deadline` (each worker computes the same one from `limits` + `now`),
+- an `AtomicBool` stop flag, so the first worker to reach the budget halts its peers.
 
-Thread 0's completed result is returned; helper threads exist only to deepen the
+Thread 0's completed result is returned, with its `nodes` replaced by the workers'
+sum (each worker's count is added up at join — no per-node shared counter, so no
+hot-path contention). Helper threads exist only to deepen the
 shared TT and desync onto other lines (the shared bounds naturally diverge the
 workers' trees). YBWC and root-splitting are rejected: weaving shared alpha,
 root-move arbitration, and cancellation through the serial alpha-beta move loop is
@@ -94,10 +95,9 @@ under `Threads > 1` anyway.
   it (extending AC-1.3 of the fair-match harness).
 - **`go nodes` forces one thread** by a hard guard in the PyO3 seam: when
   `node_limit.is_some()`, the single-thread path runs regardless of `thread_count`.
-  The aggregate node counter is incremented by racing workers, so *which* worker
-  crosses the limit first is timing-dependent — node mode is unreproducible *in
-  principle* with N>1, and per-thread sub-budgets don't save it (shared-TT desync
-  makes each worker's tree non-deterministic).
+  Under `Threads > 1` the workers desync through the shared TT, so the summed node
+  count varies run to run — node mode is unreproducible *in principle* with N>1, and
+  per-thread sub-budgets don't save it.
 - **Parallel Elo** is a time-control SPRT (`Threads = 1` vs `N` at equal wall-clock),
   never the fixed-node SPRT (whose premise is determinism). Summed worker nodes go
   to UCI `info nodes` (NPS is meaningful) but never to a term-retention decision.

--- a/roadmap/specs/parallel-search/design.md
+++ b/roadmap/specs/parallel-search/design.md
@@ -1,0 +1,155 @@
+---
+title: Parallel search — design
+description: Lazy SMP with a monomorphized generic over two TT backends — today's exclusive VecTt for Threads=1 and a lockless single-u64 AtomicTt for Threads>1.
+---
+
+> **Status:** Ready — tracked on the [board](../../ROADMAP.md). Derived from the
+> two-harness deliberation session `parallel-search` (Codex + Claude Code); the
+> recorded decisions live in `.foundry/tmp/harness-deliberation/`.
+
+# Parallel search — design
+
+## Decision summary
+
+| Decision | Choice | Why |
+|---|---|---|
+| Scheme | Lazy SMP | Matches the recursive Searcher shape; almost all the work is the shared TT. |
+| Strategy pattern | No | Thread count is a runtime knob; the scheme is build-time + A/B'd — the repo's move-ordering principle. |
+| Backend dispatch | Monomorphized generic `Searcher<Tt>` | The repo's own escape hatch (`Searcher<O: MoveOrderer>`); zero per-node virtual calls. |
+| TT (parallel) | Lockless single-u64 atomic | Hyatt key-XOR-data; no locks on the hot path, no `unsafe`. |
+| `Threads = 1` | Bit-identical to today | The deterministic basis the fair-match harness measures against. |
+| `go nodes` | Forces one thread | The aggregate node counter is a race — node mode is unreproducible with N>1. |
+| Parallel Elo | Time-control SPRT | Fixed-node's premise is determinism, which parallel search abandons. |
+
+## Lazy SMP coordinator
+
+A parallel coordinator wraps `Searcher::search`; the recursive `search_node`
+(`core/src/search.rs`) is **unchanged**. When `thread_count > 1` and no node limit
+is set, the coordinator spawns `thread_count` workers with `std::thread::scope`
+(scoped threads join at scope end — that join *is* the clean stop). Each worker
+runs today's iterative-deepening loop on a **cloned `Board`** (`Board: Clone`) with
+its own `history`, `killers`, `pv_table`, `position_history`, and `nodes`. Workers
+share only:
+
+- the `AtomicTt` (a `&` borrow through the scope),
+- the immutable `deadline`,
+- an `AtomicBool` stop flag,
+- an `AtomicU64` aggregate node counter.
+
+Thread 0's completed result is returned; helper threads exist only to deepen the
+shared TT and desync onto other lines (the shared bounds naturally diverge the
+workers' trees). YBWC and root-splitting are rejected: weaving shared alpha,
+root-move arbitration, and cancellation through the serial alpha-beta move loop is
+too much first-step risk for an engine with no concurrency today.
+
+## No strategy pattern — a monomorphized generic
+
+This follows the repo's compose-and-A/B principle from move ordering, not a runtime
+`SearchStrategy`. The rule splits cleanly:
+
+- **Runtime, one UCI option:** thread *count* — one parameterized code path.
+- **Build-time, separate builds + SPRT:** the parallelization *scheme* (Lazy SMP
+  vs YBWC) — never a runtime-swappable strategy.
+
+The `Threads` option is a *resource* knob (a UCI `spin`, as in every serious
+engine), not the eval/algorithm A/B knob the strength-harness spec rejected. The TT
+backend is selected once, cold, at search entry via a monomorphized generic
+`Searcher<Tt: TranspositionTable>` — the repo's own escape hatch
+(`Searcher<O: MoveOrderer>`) — so there are zero per-node virtual calls.
+
+## Two TT backends behind one trait
+
+The `TranspositionTable` becomes a trait — `probe(&self, zobrist) -> Option<HashEntry>`
+and `replace(&self, entry)` — and today's concrete table is renamed `VecTt`, one of
+its two implementations. `HashEntry` stays the decoded semantic record.
+
+- **`VecTt`** — today's `Vec<Option<HashEntry>>` with the same replace-by-age-or-depth
+  policy, used for `Threads = 1`. The `&self` signature gives it interior mutability
+  (`RefCell`); with one thread the borrow always succeeds and the behavior is
+  identical. Bit-identity is therefore a property of the type, guarded by the
+  determinism test — not a packing argument.
+- **`AtomicTt`** — the Hyatt lockless slot `{ key: AtomicU64, data: AtomicU64 }`
+  with `key = zobrist ^ data`, used for `Threads > 1`.
+
+**Packing (one u64).** The entry fits in 60 bits — `best_move` 16 (the `0x0000`
+quiet `a1a1`, never legal, is the `None` sentinel), `depth` 8 (range −5..=64),
+`value` 18 (`|value| ≤ MATE + ply < 2^17`), `flag` 2, `age` 16 (halfmove clock
+≤ 100) — so a single data word suffices; no two-word `mix()` scheme.
+
+- `probe`: load `data`, load `key`, accept only if `key ^ data == zobrist`. A torn
+  read (data from store A, key from store B) fails the check and returns `None` — a
+  miss, never a wrong-position hit.
+- `replace`: load `data`, decode age/depth, apply the replace-by-age-or-depth
+  policy best-effort, then store `data` and `key`.
+
+The age/depth replace race is a **speed-only** concern: TT entries are hints, a lost
+replacement costs nodes not legality, and node-count reproducibility is abandoned
+under `Threads > 1` anyway.
+
+## Determinism and measurement
+
+- **`Threads = 1` is bit-identical** because it instantiates `Searcher<VecTt>` —
+  today's exact access pattern and policy. The eval-term measurements hold by
+  construction; a `(best_move, node_count)` baseline test over a position set guards
+  it (extending AC-1.3 of the fair-match harness).
+- **`go nodes` forces one thread** by a hard guard in the PyO3 seam: when
+  `node_limit.is_some()`, the single-thread path runs regardless of `thread_count`.
+  The aggregate node counter is incremented by racing workers, so *which* worker
+  crosses the limit first is timing-dependent — node mode is unreproducible *in
+  principle* with N>1, and per-thread sub-budgets don't save it (shared-TT desync
+  makes each worker's tree non-deterministic).
+- **Parallel Elo** is a time-control SPRT (`Threads = 1` vs `N` at equal wall-clock),
+  never the fixed-node SPRT (whose premise is determinism). Summed worker nodes go
+  to UCI `info nodes` (NPS is meaningful) but never to a term-retention decision.
+- **`ucinewgame`** clears the shared TT; workers are spawned and joined inside one
+  `search()`, so none outlives a UCI command and `new_game()` clears it safely.
+
+## Configuration and boundaries
+
+The threading lives in **Rust** (the coordinator in `search.rs` or a small
+`search/parallel.rs`); Python only parses UCI. `communication.py` gains a
+`setoption` branch (it has none today) that calls a new `set_threads`; `uci`
+advertises `option name Threads type spin default 1 min 1 max <available_parallelism>`.
+`thread_count` is stored on the PyO3 `Searcher`; the default is 1; the count is
+clamped to `std::thread::available_parallelism()` (lichess-bot runs the engine as
+one process, and oversubscription loses Elo).
+
+**The GIL is released during search.** The PyO3 `search` method already takes
+`py: Python`; it wraps the Rust call in `py.allow_threads(|| …)` so the CPU search
+does not hold the GIL while N OS threads run — non-optional, since the GIL would
+serialize the workers and erase the gain.
+
+**HTTP introspection snapshots.** `entries()` cannot return references from an
+atomic table, so `/transposition_table` snapshot-decodes the slots; it runs at
+`Threads = 1` with no search in flight, so the point-in-time snapshot is well-defined.
+
+## Naming and provenance
+
+| Term | Definition | Provenance |
+|---|---|---|
+| Lazy SMP | Parallel search where each thread runs the full search, sharing one TT | CPW "Lazy SMP" |
+| Lockless transposition table | A shared TT using the key-XOR-data trick to reject torn reads | Robert Hyatt; CPW "Shared Hash Table" |
+| Threads (UCI option) | The worker count, a `spin` resource option | UCI `option`; standard engine convention |
+
+## Alternatives considered
+
+- **YBWC / root-splitting.** Rejected as a first step: far more complex (split
+  points, shared alpha, cancellation) and superseded by Lazy SMP.
+- **Sharded-mutex TT.** Rejected: a lock on every hot-path probe/replace.
+- **Per-thread TTs.** Rejected: helpers stop sharing bounds, defeating Lazy SMP.
+- **Two-data-word packing (Stockfish-style).** Rejected: the entry fits one u64, so
+  a second word and a `mix()` only widen the torn-read window.
+- **Two concrete code paths** (no generic). Rejected: duplicates the negamax logic;
+  the monomorphized generic matches the repo's `Searcher<O: MoveOrderer>` and the
+  determinism guard de-risks the `VecTt` interior-mutability change.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Lockless correctness is subtle | A torn-read rejection test; `AtomicU64` only, no `unsafe`. |
+| Identical workers duplicate effort before TT desync | The speedup is empirical — measure with the time-control SPRT before claiming Elo. |
+| `go nodes` non-reproducible under threads | A hard single-thread guard in the seam + a test. |
+| GIL held during search serializes workers | `py.allow_threads` around the Rust call (mandatory). |
+| Oversubscription loses Elo | Default 1; clamp to `available_parallelism()`. |
+| Baseline regression from the generic | The `Threads = 1` `(best_move, node_count)` determinism guard. |

--- a/roadmap/specs/parallel-search/design.md
+++ b/roadmap/specs/parallel-search/design.md
@@ -37,11 +37,53 @@ share only:
 
 Thread 0's completed result is returned, with its `nodes` replaced by the workers'
 sum (each worker's count is added up at join — no per-node shared counter, so no
-hot-path contention). Helper threads exist only to deepen the
-shared TT and desync onto other lines (the shared bounds naturally diverge the
-workers' trees). YBWC and root-splitting are rejected: weaving shared alpha,
+hot-path contention). YBWC and root-splitting are rejected: weaving shared alpha,
 root-move arbitration, and cancellation through the serial alpha-beta move loop is
 too much first-step risk for an engine with no concurrency today.
+
+This Wave 1–4 coordinator runs every worker **identically** — the same iterative
+deepening from depth 1 — relying on timing and the shared TT to desync them. Wave
+5.1 measured that at **−17 Elo [−46.3, +11.2]** (Threads=8 vs Threads=1, time
+control): a wash. The workers re-search the same tree, so the shared TT only
+deduplicates redundant work. Search diversity is what converts the node throughput
+into Elo.
+
+## Search diversity — staggered depths and thread voting
+
+Two mechanisms make the workers search *differently*. Both touch only the
+`Threads > 1` path; worker 0 and the single-threaded `Searcher` are unchanged, so
+AC-2.2 bit-identity holds by construction.
+
+### Staggered depths (a skip schedule)
+
+Worker 0 is the **main line**: it searches every depth `1, 2, 3, …` and never skips,
+so a complete result always exists. Each **helper** `i > 0` skips a subset of depths
+on a deterministic pattern keyed on `i`, spreading the helpers across plies — they
+fill the TT with bounds from different depths instead of all racing the same one. We
+adopt Stockfish's `SkipSize`/`SkipPhase` scheme (`search.cpp`): with `j = (i − 1) mod
+20`, worker `i` skips root depth `d` when `((d + SkipPhase[j]) / SkipSize[j])` is
+odd; the two length-20 tables fan the helpers over a range of depth offsets.
+
+Integration: the iterative-deepening loop in `Searcher::search` gains a `skip(depth)`
+predicate (a no-op for `Threads = 1` and worker 0). `search_node` is unchanged.
+
+### Thread voting
+
+Returning worker 0 wastes the helpers' finds. Instead, each worker contributes its
+final `(best_move, depth, score)`, and the coordinator **votes** — with `min_score`
+the minimum score over the workers:
+
+```
+weight(worker)     = (worker.score − min_score + 1) × worker.depth
+votes[best_move]  += weight(worker)        # summed over all workers
+```
+
+The move with the greatest summed vote wins; among the workers proposing it the
+deepest is selected and its principal variation and score are reported (AC-7.3–7.4).
+This rewards a move that several deep, high-scoring workers agree on — Stockfish's
+`Thread::best_thread` rule. Mate scores are the one special case: a worker reporting
+a nearer mate outvotes a deeper non-mate. The vote runs once, at the
+`std::thread::scope` join — no hot-path cost.
 
 ## No strategy pattern — a monomorphized generic
 
@@ -130,6 +172,8 @@ atomic table, so `/transposition_table` snapshot-decodes the slots; it runs at
 | Lazy SMP | Parallel search where each thread runs the full search, sharing one TT | CPW "Lazy SMP" |
 | Lockless transposition table | A shared TT using the key-XOR-data trick to reject torn reads | Robert Hyatt; CPW "Shared Hash Table" |
 | Threads (UCI option) | The worker count, a `spin` resource option | UCI `option`; standard engine convention |
+| Depth staggering | A per-helper depth-skip schedule so the workers search different plies | Stockfish `SkipSize`/`SkipPhase` (`search.cpp`) |
+| Thread voting | Selecting the reported move by a depth-and-score-weighted vote across workers | Stockfish `Thread::best_thread` |
 
 ## Alternatives considered
 
@@ -148,7 +192,9 @@ atomic table, so `/transposition_table` snapshot-decodes the slots; it runs at
 | Risk | Mitigation |
 |---|---|
 | Lockless correctness is subtle | A torn-read rejection test; `AtomicU64` only, no `unsafe`. |
-| Identical workers duplicate effort before TT desync | The speedup is empirical — measure with the time-control SPRT before claiming Elo. |
+| Identical workers duplicate effort before TT desync | Staggered depths + thread voting (Search diversity); measure with the time-control SPRT before claiming Elo. |
+| Diversity gain is empirical and modest | Re-measure vs both Threads=1 and the lockstep baseline; basic Lazy SMP is tens of Elo, not hundreds. |
+| Vote picks a worse move than the deepest worker | Weight by depth and score; prefer shorter mates; a unit test on a constructed worker set. |
 | `go nodes` non-reproducible under threads | A hard single-thread guard in the seam + a test. |
 | GIL held during search serializes workers | `py.allow_threads` around the Rust call (mandatory). |
 | Oversubscription loses Elo | Default 1; clamp to `available_parallelism()`. |

--- a/roadmap/specs/parallel-search/requirements.md
+++ b/roadmap/specs/parallel-search/requirements.md
@@ -1,0 +1,63 @@
+---
+title: Parallel search — requirements
+description: Multi-threaded Lazy SMP search that deepens within the same time budget, with the single-threaded path preserved bit-identical as the deterministic measurement basis.
+---
+
+> **Status:** Ready — tracked on the [board](../../ROADMAP.md). Derived from the
+> two-harness deliberation session `parallel-search` (Codex + Claude Code).
+
+# Parallel search — requirements
+
+The engine searches single-threaded. This feature adds Lazy SMP — N worker
+searches sharing one transposition table — so the engine deepens further within
+the same time budget. `Threads = 1` stays the default and bit-identical to today,
+because the fair-match harness measures eval terms against that deterministic
+path; a separate time-control match measures the parallel speedup.
+
+## Story 1 — Parallel search
+
+As the maintainer, I want the engine to search across cores, so it reaches greater
+depth in the same time and plays stronger on lichess.
+
+- AC-1.1 WHEN `Threads` is greater than 1, THE SYSTEM SHALL run `Threads` worker searches in parallel that share one transposition table.
+- AC-1.2 WHEN the parallel search finishes, THE SYSTEM SHALL report the first worker's completed result (best move and principal variation).
+- AC-1.3 WHEN the time budget expires, THE SYSTEM SHALL stop every worker and return the best result from a completed iteration.
+
+## Story 2 — The deterministic basis is preserved
+
+As the maintainer, I want single-threaded search untouched, so the eval-term
+measurements still hold.
+
+- AC-2.1 THE SYSTEM SHALL default `Threads` to 1.
+- AC-2.2 WHEN `Threads` is 1, THE SYSTEM SHALL produce the same best move and the same node count as the single-threaded engine for any position (bit-identical).
+- AC-2.3 WHEN a node limit is set (`go nodes`), THE SYSTEM SHALL run a single thread regardless of the `Threads` value.
+
+## Story 3 — Lockless shared transposition table
+
+As the maintainer, I want a thread-safe TT without locks on the hot path, so the
+workers actually share their work.
+
+- AC-3.1 WHEN `Threads` is greater than 1, THE SYSTEM SHALL store and probe transposition entries without locks.
+- AC-3.2 WHEN a transposition slot is read mid-write (a torn read), THE SYSTEM SHALL return a miss, never an entry for a different position.
+
+## Story 4 — Thread configuration
+
+As the maintainer, I want a standard `Threads` UCI option, so a bridge or GUI can
+set the worker count.
+
+- AC-4.1 WHEN it receives `setoption name Threads value N`, THE SYSTEM SHALL set the worker count, clamped to the available core count.
+- AC-4.2 WHEN it receives `uci`, THE SYSTEM SHALL advertise `option name Threads type spin default 1 min 1 max <available_parallelism>` before `uciok`.
+
+## Story 5 — Measured speedup
+
+As the maintainer, I want the parallel gain measured honestly, so a claimed Elo
+gain is real and not a fixed-node artifact.
+
+- AC-5.1 WHEN measuring the parallel speedup, THE SYSTEM SHALL use a time-control SPRT (`Threads = 1` vs `Threads = N` at equal wall-clock), not the fixed-node SPRT.
+- AC-5.2 WHEN it reports `info`, THE SYSTEM SHALL sum worker nodes for `nodes`, and that sum SHALL NOT feed an eval-term retention decision.
+
+## Story 6 — Guarded by the gate
+
+As the maintainer, I want the existing gate green and the new behavior tested.
+
+- AC-6.1 WHEN `scripts/check-fast.sh` runs, THE SYSTEM SHALL pass perft and the tactical tests at `Threads = 1`, plus a `Threads = 1` `(best_move, node_count)` determinism baseline, `setoption` parsing, the `go nodes` single-thread guard, and a lockless torn-read rejection test.

--- a/roadmap/specs/parallel-search/requirements.md
+++ b/roadmap/specs/parallel-search/requirements.md
@@ -61,3 +61,16 @@ gain is real and not a fixed-node artifact.
 As the maintainer, I want the existing gate green and the new behavior tested.
 
 - AC-6.1 WHEN `scripts/check-fast.sh` runs, THE SYSTEM SHALL pass perft and the tactical tests at `Threads = 1`, plus a `Threads = 1` `(best_move, node_count)` determinism baseline, `setoption` parsing, the `go nodes` single-thread guard, and a lockless torn-read rejection test.
+
+## Story 7 — Search diversity
+
+As the maintainer, I want the worker threads to search *differently*, so the extra
+nodes find moves the main line misses instead of re-searching the same tree —
+turning parallel node throughput into Elo. (Wave 5.1 measured the lockstep
+coordinator at a wash; this story is its payoff.)
+
+- AC-7.1 WHEN `Threads` is greater than 1, THE SYSTEM SHALL give each helper worker a distinct depth schedule — staggered, skipped iteration depths keyed on the worker index — so the workers do not all search the same depth in lockstep.
+- AC-7.2 WHEN `Threads` is 1, or for worker 0 under `Threads > 1`, THE SYSTEM SHALL search every depth in order with no skipping, preserving the bit-identical single-threaded basis (AC-2.2) and a complete main line.
+- AC-7.3 WHEN the parallel search finishes, THE SYSTEM SHALL choose the returned best move by a vote across workers weighted by each worker's reached depth and score, not by unconditionally taking worker 0.
+- AC-7.4 WHEN a vote selects a worker, THE SYSTEM SHALL report that worker's principal variation and score; a worker reporting a nearer mate SHALL outvote a deeper non-mate.
+- AC-7.5 WHEN measuring, THE SYSTEM SHALL record a time-control SPRT of the diversified `Threads = N` against `Threads = 1`, and the gate SHALL keep the `Threads = 1` determinism baseline green.

--- a/roadmap/specs/parallel-search/tasks.md
+++ b/roadmap/specs/parallel-search/tasks.md
@@ -15,15 +15,15 @@ determinism baseline guards every later wave.
 ## Wave 1 — Generic TT backend
 
 - **1.1 `TranspositionTable` trait + generic `Searcher`.** Make `TranspositionTable`
-  a trait (`probe(&self)`, `replace(&self)`); rename today's concrete table `VecTt`
-  and make `Searcher` generic over the trait. Convert `VecTt`'s `probe`/`replace` to
+  a trait (`probe(&self)`, `replace(&self)`); rename today's concrete table `ExclusiveTranspositionTable`
+  and make `Searcher` generic over the trait. Convert `ExclusiveTranspositionTable`'s `probe`/`replace` to
   `&self` with interior mutability, keeping the replace-by-age-or-depth policy. *Gate: AC-2.2 — a `Threads=1`
   `(best_move, node_count)` baseline over a position set is unchanged; perft and the
   tactical tests stay green.*
 
 ## Wave 2 — Lockless atomic table
 
-- **2.1 `AtomicTt`.** The Hyatt single-u64 lockless slot
+- **2.1 `LocklessTranspositionTable`.** The Hyatt single-u64 lockless slot
   `{ key: AtomicU64 = zobrist ^ data, data: AtomicU64 }`; pack/unpack `HashEntry`
   into one 60-bit `data` word. `probe` accepts only if `key ^ data == zobrist`.
   No `unsafe`. *Gate: AC-3.1–3.2 — a torn-read rejection test: a mismatched
@@ -33,7 +33,7 @@ determinism baseline guards every later wave.
 
 - **3.1 Parallel coordinator.** When `thread_count > 1` and no node limit, spawn
   `thread_count` workers with `std::thread::scope`, each running the iterative-deepening
-  loop on a cloned `Board` with per-worker state, sharing the `AtomicTt`, the
+  loop on a cloned `Board` with per-worker state, sharing the `LocklessTranspositionTable`, the
   `deadline`, an `AtomicBool` stop, and an `AtomicU64` node counter. Return thread 0's
   result. *Gate: AC-1.1–1.3 — a multi-thread search returns a legal move and stops
   within the budget; `search_node` is unchanged.*

--- a/roadmap/specs/parallel-search/tasks.md
+++ b/roadmap/specs/parallel-search/tasks.md
@@ -1,0 +1,60 @@
+---
+title: Parallel search — tasks
+description: Waved plan — generic TT backend, lockless atomic table, Lazy SMP coordinator, config seam, and measurement; each task names its gate.
+---
+
+> **Status:** Ready — tracked on the [board](../../ROADMAP.md). Derived from the
+> two-harness deliberation session `parallel-search`.
+
+# Parallel search — tasks
+
+Tasks within a wave are independent; each wave builds on the last. Every task names
+its gate. The single-threaded path must stay bit-identical throughout — Wave 1's
+determinism baseline guards every later wave.
+
+## Wave 1 — Generic TT backend
+
+- **1.1 `TranspositionTable` trait + generic `Searcher`.** Make `TranspositionTable`
+  a trait (`probe(&self)`, `replace(&self)`); rename today's concrete table `VecTt`
+  and make `Searcher` generic over the trait. Convert `VecTt`'s `probe`/`replace` to
+  `&self` with interior mutability, keeping the replace-by-age-or-depth policy. *Gate: AC-2.2 — a `Threads=1`
+  `(best_move, node_count)` baseline over a position set is unchanged; perft and the
+  tactical tests stay green.*
+
+## Wave 2 — Lockless atomic table
+
+- **2.1 `AtomicTt`.** The Hyatt single-u64 lockless slot
+  `{ key: AtomicU64 = zobrist ^ data, data: AtomicU64 }`; pack/unpack `HashEntry`
+  into one 60-bit `data` word. `probe` accepts only if `key ^ data == zobrist`.
+  No `unsafe`. *Gate: AC-3.1–3.2 — a torn-read rejection test: a mismatched
+  key/data pair probes as a miss; a matched pair round-trips.*
+
+## Wave 3 — Lazy SMP coordinator
+
+- **3.1 Parallel coordinator.** When `thread_count > 1` and no node limit, spawn
+  `thread_count` workers with `std::thread::scope`, each running the iterative-deepening
+  loop on a cloned `Board` with per-worker state, sharing the `AtomicTt`, the
+  `deadline`, an `AtomicBool` stop, and an `AtomicU64` node counter. Return thread 0's
+  result. *Gate: AC-1.1–1.3 — a multi-thread search returns a legal move and stops
+  within the budget; `search_node` is unchanged.*
+
+## Wave 4 — Configuration & seam
+
+- **4.1 `Threads` option.** Add `setoption` parsing to `communication.py` (none
+  today) and `set_threads`; advertise `option name Threads type spin default 1 min 1
+  max <available_parallelism>` on `uci`; store `thread_count` on the PyO3 `Searcher`;
+  clamp to `available_parallelism()`. *Gate: AC-4.1–4.2 — a `setoption` parsing test
+  and the advertised option on `uci`.*
+- **4.2 Seam guards.** Force the single-thread path when `node_limit.is_some()`;
+  wrap the Rust search in `py.allow_threads`; snapshot-decode the atomic TT for
+  `/transposition_table`. *Gate: AC-2.3 — `go nodes` resolves to one thread (test).*
+
+## Wave 5 — Measure, docs & board
+
+- **5.1 Time-control SPRT.** A `Threads=1` vs `Threads=N` time-control match through
+  the existing harness; record the Elo gain. *Gate: AC-5.1 — the gain is recorded;
+  summed parallel nodes never feed a term decision.*
+- **5.2 Docs & board.** Add `Lazy SMP`, `lockless transposition table`, and the
+  `Threads` option to `knowledge/glossary.md` with provenance; note the option in
+  `AGENTS.md`; move the Epic 5 cards to Done. *Gate: `python3 scripts/knowledge.py
+  check` clean; recorded gate PASS.*

--- a/roadmap/specs/parallel-search/tasks.md
+++ b/roadmap/specs/parallel-search/tasks.md
@@ -54,7 +54,31 @@ determinism baseline guards every later wave.
 - **5.1 Time-control SPRT.** A `Threads=1` vs `Threads=N` time-control match through
   the existing harness; record the Elo gain. *Gate: AC-5.1 — the gain is recorded;
   summed parallel nodes never feed a term decision.*
+  **Measured (2026-06-29):** Threads=8 vs Threads=1 (both NNUE, `--movetime 400`,
+  80 pairs via `sprt.py --movetime`): **−17.4 Elo [−46.3, +11.2]** — a wash (CI spans
+  zero, 61% draws). The lockstep workers re-search the same tree; the gain awaits
+  Wave 6 (search diversity). Confound noted: `Threads=8` also swaps in the lossier
+  packed lockless table, so part of the deficit is the table, not the threads.
 - **5.2 Docs & board.** Add `Lazy SMP`, `lockless transposition table`, and the
   `Threads` option to `knowledge/glossary.md` with provenance; note the option in
   `AGENTS.md`; move the Epic 5 cards to Done. *Gate: `python3 scripts/knowledge.py
   check` clean; recorded gate PASS.*
+
+## Wave 6 — Search diversity
+
+- **6.1 Staggered depths.** Add a per-worker `skip(depth)` schedule to the
+  iterative-deepening loop (Stockfish `SkipSize`/`SkipPhase`, keyed on the worker
+  index); worker 0 and `Threads = 1` never skip. *Gate: AC-7.1–7.2 — helpers skip a
+  documented depth set; the `Threads = 1` `(best_move, node_count)` determinism
+  baseline stays green.*
+- **6.2 Thread voting.** Replace the unconditional thread-0 return with the
+  depth-and-score-weighted vote (`weight = (score − min_score + 1) × depth`); report
+  the winning worker's PV and score; prefer shorter mates. *Gate: AC-7.3–7.4 — a unit
+  test that a constructed worker set votes for the agreed deep move, and that a mate
+  worker outvotes a deeper non-mate.*
+- **6.3 Re-measure.** Re-run the time-control SPRT (`Threads = 1` vs diversified
+  `Threads = N`) and record the Elo delta against the Wave 5.1 lockstep baseline.
+  *Gate: AC-7.5 — the gain is recorded; the determinism baseline stays green.*
+- **6.4 Docs & glossary.** Add `depth staggering` and `thread voting` to
+  `knowledge/glossary.md` with provenance. *Gate: `python3 scripts/knowledge.py check`
+  clean; recorded gate PASS.*

--- a/scripts/sprt.py
+++ b/scripts/sprt.py
@@ -321,6 +321,13 @@ def main():
     parser.add_argument(
         "--nodes", type=int, default=200_000, help="fixed node budget per move"
     )
+    parser.add_argument(
+        "--movetime",
+        type=int,
+        default=None,
+        help="per-move time in ms (time control; overrides --nodes — needed to measure "
+        "Lazy SMP, which the node limit forces back to one thread)",
+    )
     parser.add_argument("--elo0", type=float, default=0.0, help="H0 Elo bound")
     parser.add_argument("--elo1", type=float, default=5.0, help="H1 Elo bound")
     parser.add_argument("--alpha", type=float, default=0.05, help="type-I error rate")
@@ -363,7 +370,11 @@ def main():
     # pair source is lazy, so run_sprt's max_pairs caps the run without truncating
     # the book (truncating it would collapse the census CI at exhaustion).
     population = len(openings)
-    limit = match_core.make_limit(None, None, nodes=args.nodes)
+    limit = (
+        match_core.make_limit(args.movetime, None)
+        if args.movetime
+        else match_core.make_limit(None, None, nodes=args.nodes)
+    )
 
     pairs = _engine_pairs(
         shlex.split(args.engine1),

--- a/src/communication.py
+++ b/src/communication.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import sys
 
 import brandobot_core
@@ -21,10 +22,13 @@ def talk():
     chess to brandobot_core. A single Searcher holds the game's position and
     transposition table."""
     searcher = brandobot_core.Searcher()
-    depth, net = parse_engine_args()
+    depth, net, threads = parse_engine_args()
     if net:
         searcher.load_nnue(net)
         print(f">>> loaded nnue: {net}", file=sys.stderr)
+    if threads > 1:
+        searcher.set_threads(threads)
+        print(f">>> threads: {threads}", file=sys.stderr)
 
     while True:
         message = input()
@@ -41,6 +45,7 @@ def command(searcher, depth, message):
     if message == "uci":
         print("id name brandobot")
         print("id author Brandon Ransom")
+        print(f"option name Threads type spin default 1 min 1 max {os.cpu_count() or 1}")
         print("uciok")
         return
 
@@ -52,6 +57,10 @@ def command(searcher, depth, message):
         searcher.new_game()
         return
 
+    if message.startswith("setoption"):
+        set_option(searcher, message)
+        return
+
     if message.startswith("position"):
         set_position(searcher, message)
         return
@@ -59,6 +68,18 @@ def command(searcher, depth, message):
     if message.startswith("go"):
         go(searcher, depth, message)
         return
+
+
+def set_option(searcher, message):
+    """Handle `setoption name <Name> value <Value>`. Only `Threads` is supported —
+    it sets the Lazy SMP worker count, clamped to `[1, cpu_count]`."""
+    tokens = message.split()
+    if "name" not in tokens or "value" not in tokens:
+        return
+    name = tokens[tokens.index("name") + 1].lower()
+    value = tokens[tokens.index("value") + 1]
+    if name == "threads":
+        searcher.set_threads(min(max(1, int(value)), os.cpu_count() or 1))
 
 
 def go(searcher, default_depth, message):
@@ -134,5 +155,8 @@ def parse_engine_args():
     parser.add_argument(
         "--net", default=None, help="NNUE network file; omit for the hand-written eval"
     )
+    parser.add_argument(
+        "--threads", type=int, default=1, help="Lazy SMP worker threads (default: 1)"
+    )
     args, _ = parser.parse_known_args()
-    return int(args.depth), args.net
+    return int(args.depth), args.net, int(args.threads)


### PR DESCRIPTION
Lazy SMP parallel search, **rebased onto current `main`** (after the NNUE work merged).

## Implemented (Waves 1–4)
- **Wave 1** generic `TranspositionTable` trait + `Searcher<Tt>` (the `Threads=1` path stays bit-identical via `ExclusiveTranspositionTable`).
- **Wave 2** `LocklessTranspositionTable` (Hyatt key-XOR-data, packed 60-bit slot).
- **Wave 3** `search_parallel` Lazy SMP coordinator (`std::thread::scope`, shared TT + stop flag).
- **Wave 4** the `Threads` UCI option + `--threads` flag, routed to `search_parallel` when time-based; the NNUE net threaded through the workers. `Threads=8` searches ~6.5× the nodes of `Threads=1`.

## Measured (Wave 5.1) — and why it's not mergeable for strength yet
Time-control SPRT, Threads=8 vs Threads=1 (both NNUE, movetime 400, 80 pairs): **−17.4 Elo [−46.3, +11.2]** — a wash. The lockstep workers re-search the same tree (no diversity), and `Threads=8` also swaps in the lossier packed table.

## Next (Wave 6 spec, in this PR)
`roadmap/specs/parallel-search` now specs **search diversity** — staggered depths (Stockfish `SkipSize`/`SkipPhase`) + thread voting — the mechanisms that convert the node throughput into Elo. Implementation pending.

**Status: WIP** — hold the merge until Wave 6 proves a positive time-control SPRT.

https://claude.ai/code/session_018XtCQkFZJe5r72WEnGiF1H