### PR TITLE
docs: revise AGENTS.md + sync foundry templates to 0.1.10

### DIFF
--- a/.foundry/manifest.json
+++ b/.foundry/manifest.json
@@ -1,5 +1,5 @@
 {
-  "pluginVersion": "0.1.8",
+  "pluginVersion": "0.1.10",
   "conventionVersion": 3,
   "harnesses": ["claude-code", "codex"],
   "files": {
@@ -46,7 +46,7 @@
     "scripts/worktree-retire.sh": {
       "template": "worktree-retire",
       "version": 1,
-      "sha256": "4b9bf74f34988607172dbb903b9dcce0b9e66e992132f930fb7c4a6b598e0943"
+      "sha256": "94bf1f4d2a1b6a01acb0aab8f3b09e8041eedfcf844484ef8f7910370323f82e"
     }
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@ python3 -m venv .venv && .venv/bin/pip install -r requirements-dev.txt
 .venv/bin/maturin develop --release -m core/Cargo.toml   # build the Rust core into the venv
 scripts/check-fast.sh            # canonical gate: cargo fmt/clippy/test + maturin + ruff + pytest + knowledge
 .venv/bin/python src/main.py     # run the UCI engine (type: uci, isready, go, quit)
+.venv/bin/python src/main.py --net nets/net.nnue   # UCI engine with the NNUE eval
 .venv/bin/python src/api.py      # run the Flask HTTP API
 .venv/bin/python src/perft.py    # move-generation benchmark
 .venv/bin/python scripts/epd_suite.py --movetime 100 bench/wac.epd  # tactical solve-rate
@@ -15,61 +16,59 @@ scripts/check-fast.sh            # canonical gate: cargo fmt/clippy/test + matur
 scripts/board.sh                 # render the kanban board from roadmap/ROADMAP.md
 ```
 
-Pre-push runs the same gate: run `scripts/install-hooks.sh` once per clone;
-bypass once with `git push --no-verify`.
+Pre-push runs the same gate: run `scripts/install-hooks.sh` once per clone; bypass
+once with `git push --no-verify`.
+
+## Done
+
+Done is a recorded gate PASS — `scripts/check-fast.sh` green. Never claim it from a
+partial run, or mark a board card `Done` without one.
 
 ## Boundaries
 
 **Never**
-- Introduce vocabulary from outside the chess and game-tree-search domain. This
-  is a neutral engine; `knowledge/glossary.md` is the contract.
+- Commit secrets — the lichess-bot token, API keys.
+- `git add -A`; stage explicit paths.
+- Introduce vocabulary from outside the chess / game-tree-search domain;
+  `knowledge/glossary.md` is the contract.
 
 **Always**
-- Use the `knowledge/glossary.md` vocabulary in records, APIs, and concepts — it
-  is the domain language.
-- Before coining a canonical name (glossary term, public type or field, config
-  knob), search the prior art and record provenance in the glossary.
-- Stage explicit paths, never `git add -A`.
+- Use the `knowledge/glossary.md` vocabulary in records, APIs, and concepts.
+- Before coining a canonical name (glossary term, public type or field, config knob),
+  search the prior art and record provenance in the glossary.
 
 **Ask first**
 - Push to remote. Branch first if on the default branch.
 
-## Writing style
-
-Omit needless words; use the active voice; make
-definite assertions. Lead with the point; one idea per sentence; concrete
-commands, paths, and names; say it once and link to depth. Prefer a table, list,
-or code block when denser than a sentence.
-
 ## Testing
 
-- Run the gate's tests: `.venv/bin/python -m pytest -q`.
-- Scope to one file: `.venv/bin/python -m pytest src/tests/next_move.py -q`, or
-  run a unittest file directly: `.venv/bin/python src/tests/next_move.py`.
-- Integration over mocks: unit tests drive `Board`/`Searcher`; the acceptance
-  Scenario drives the real UCI engine via subprocess. No mocks.
+- Gate tests `.venv/bin/python -m pytest -q`; one file
+  `.venv/bin/python -m pytest src/tests/next_move.py -q`.
+- Integration over mocks: unit tests drive `Board`/`Searcher`; the acceptance Scenario
+  drives the real UCI engine via subprocess.
 - New feature → add a Scenario; enhancement → update it; refactor → leave it.
 
 ## Contracts
 
-The engine exposes two contracts:
-- **UCI command set** over stdin/stdout: `uci`, `isready`, `ucinewgame`,
-  `position`, `go`, `quit`.
-- **HTTP JSON API**: `POST /next_move` `{fen}` → `{move}`; `GET
-  /transposition_table`; `GET /decision_tree`.
+Two contracts, each exercised through its entrypoint in a Scenario:
+- **UCI** over stdin/stdout: `uci`, `isready`, `ucinewgame`, `position`, `go`, `quit`.
+- **HTTP JSON**: `POST /next_move {fen}` → `{move}`; `GET /transposition_table`;
+  `GET /decision_tree`.
 
-Write the schema first; derive types from it — never parallel hand-written
-types. Validate at every boundary (parse, don't trust); model request and
-response with pydantic. Feature Scenarios exercise each contract through its
-production entrypoint.
+Write the schema first and derive types from it. Validate at every boundary (parse,
+don't trust); model request and response with pydantic.
+
+## Writing style
+
+Omit needless words; use the active voice; make definite assertions. Lead with the
+point; one idea per sentence; concrete commands, paths, and names; say it once and link
+to depth. Prefer a table, list, or code block when denser than a sentence.
 
 ## Task tracking
 
-`roadmap/ROADMAP.md` is the board; claim a card by owner; `Done` requires a
-recorded gate PASS. Specs live in `roadmap/specs/<feature>/`; ideas in
-`roadmap/BACKLOG.md`.
+`roadmap/ROADMAP.md` is the board; claim a card by owner. Specs live in
+`roadmap/specs/<feature>/`; ideas in `roadmap/BACKLOG.md`.
 
 ## Deeper docs
 
 `knowledge/README.md` indexes everything · glossary · validation · specs.
-

--- a/scripts/worktree-retire.sh
+++ b/scripts/worktree-retire.sh
@@ -13,20 +13,31 @@
 # Promote durable notes to the TRACKED tree first (roadmap/ROADMAP.md, roadmap/specs/,
 # roadmap/BACKLOG.md), commit, then retire. `--force` deletes anyway.
 #
-# Usage: scripts/worktree-retire.sh <worktree-path> [--force]
+# `--delete-branch` also deletes the worktree's branch after removal — `git
+# branch -d` (merge-safe; refuses an unmerged branch), or `git branch -D` under
+# `--force`. Run it from within the owning repo. Branch deletion runs only after
+# note-protection and worktree removal succeed.
+#
+# Usage: scripts/worktree-retire.sh <worktree-path> [--force] [--delete-branch]
 set -euo pipefail
 
 force=0
+delete_branch=0
 wt=""
 for arg in "$@"; do
   case "$arg" in
     --force) force=1 ;;
+    --delete-branch) delete_branch=1 ;;
     -*) echo "worktree-retire: unknown flag $arg" >&2; exit 2 ;;
     *) wt="$arg" ;;
   esac
 done
-[ -n "$wt" ] || { echo "usage: scripts/worktree-retire.sh <worktree-path> [--force]" >&2; exit 2; }
+[ -n "$wt" ] || { echo "usage: scripts/worktree-retire.sh <worktree-path> [--force] [--delete-branch]" >&2; exit 2; }
 [ -d "$wt" ] || { echo "worktree-retire: not a directory: $wt" >&2; exit 2; }
+
+# Record the branch before removal so we can delete it afterward.
+branch=""
+[ "$delete_branch" -eq 1 ] && branch="$(git -C "$wt" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
 
 # Durable-note patterns we refuse to drop on the floor.
 note_re='(^|/)(.*followup|.*handoff|.*scratch|.*notes|TODO)'
@@ -53,4 +64,14 @@ else
   git worktree remove "$wt"
 fi
 git worktree prune
+
+if [ "$delete_branch" -eq 1 ] && [ -n "$branch" ]; then
+  if [ "$force" -eq 1 ]; then
+    echo "worktree-retire: deleting branch $branch (--force)"
+    git branch -D "$branch"
+  else
+    echo "worktree-retire: deleting branch $branch"
+    git branch -d "$branch"
+  fi
+fi
 echo "worktree-retire: done."


### PR DESCRIPTION
Two small housekeeping commits.

## Revise AGENTS.md (per the [agents.md standard](https://agents.md/))
- **+ `Done` section** — done = a recorded `check-fast.sh` gate PASS (verifiable criteria)
- **+ secrets boundary** — never commit the lichess-bot token / API keys
- **+ `--net nets/net.nnue`** run command (NNUE eval)
- tightened Contracts to operational rules; merged duplicated test/never clauses
- dropped the architectural intro blurb + redundant words (net shorter: 74 vs 75 lines)

`CLAUDE.md` is a symlink to `AGENTS.md`, so it's single-source (already follows the
unified-standard best practice).

## Sync foundry templates to 0.1.10
No convention break (repo is at convention 3, the registry head); 8/9 templates are
byte-identical. The only change in 0.1.10 is `worktree-retire.sh` gaining a
`--delete-branch` option (the plugin shipped it without bumping its `v1` marker; the
repo copy was pristine, so refreshing is safe). Bumps the manifest to 0.1.10.

Gate: `check-fast.sh` **PASS** (60 Rust tests, 47 pytest, ruff, knowledge).

https://claude.ai/code/session_018XtCQkFZJe5r72WEnGiF1H